### PR TITLE
Temporarily downgrad to composer `v2.6` in CI

### DIFF
--- a/.github/workflows/php_linter.yml
+++ b/.github/workflows/php_linter.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, zip
+          tools: composer:2.6
 
       - name: Install Composer Dependencies
         run: |


### PR DESCRIPTION
Currently running the lint CI fails with

```
   Error 

  Class "app\Console\Commands\AbstractSharedCommand" not found

  at app/Console/Commands/MailApplianceDebtsCommand.php:8
      4▕ 
      5▕ use App\Services\ApplianceRateService;
      6▕ use MPM\OutstandingDebts\OutstandingDebtsExportService;
      7▕ 
  ➜   8▕ class MailApplianceDebtsCommand extends AbstractSharedCommand
      9▕ {
     10▕     protected $signature = 'mail:appliance-debts';
     11▕ 
     12▕     protected $description = 'Send mail to customers with appliance debts';

      +2 vendor frames 
  3   [internal]:0
      Composer\Autoload\ClassLoader::loadClass()

      +1 vendor frames 
  5   app/Console/Kernel.php:73
      Illuminate\Console\Scheduling\Schedule::command()
```

Somehow related to Composer 2.7.

For now we downgrade composer on the CI, until we find a solution.