### PR TITLE
Fix Laravel Horizon UI

### DIFF
--- a/Website/htdocs/mpmanager/app/Http/Middleware/UserDefaultDatabaseConnectionMiddleware.php
+++ b/Website/htdocs/mpmanager/app/Http/Middleware/UserDefaultDatabaseConnectionMiddleware.php
@@ -59,6 +59,10 @@ class UserDefaultDatabaseConnectionMiddleware
             return $next($request);
         }
 
+        if (strpos($request->path(), 'horizon') === 0) {
+            return $next($request);
+        }
+
         // webclient login
         if ($request->path() === 'api/auth/login' || $request->path() === 'api/app/login') {
             $databaseProxy = $this->databaseProxyManager->findByEmail($request->input('email'));


### PR DESCRIPTION
Currently, in the local development environment Laravel Horizon is not working:

<img width="1512" alt="image" src="https://github.com/EnAccess/micropowermanager/assets/14202480/878fa5f0-881f-4298-a837-a30eb5ceba37">

This PR fixes it and can now access Horizon at http://localhost:8000/horizon/dashboard

<img width="1500" alt="image" src="https://github.com/EnAccess/micropowermanager/assets/14202480/202c6538-f0cd-45a4-963e-87360d339280">
