### PR TITLE
Fix some sidebar highlighting

### DIFF
--- a/Website/ui/package-lock.json
+++ b/Website/ui/package-lock.json
@@ -42,7 +42,7 @@
         "vue-morris": "^1.1.0",
         "vue-multiselect": "^2.1.6",
         "vue-notification": "^1.3.20",
-        "vue-router": "^3.4.5",
+        "vue-router": "^3.6.5",
         "vue-sweetalert2": "^1.6.4",
         "vue-tel-input": "^5.11.0",
         "vue-template-compiler": "^2.5.17",

--- a/Website/ui/package.json
+++ b/Website/ui/package.json
@@ -71,7 +71,7 @@
     "vue-morris": "^1.1.0",
     "vue-multiselect": "^2.1.6",
     "vue-notification": "^1.3.20",
-    "vue-router": "^3.4.5",
+    "vue-router": "^3.6.5",
     "vue-sweetalert2": "^1.6.4",
     "vue-tel-input": "^5.11.0",
     "vue-template-compiler": "^2.5.17",

--- a/Website/ui/src/classes/paginator.js
+++ b/Website/ui/src/classes/paginator.js
@@ -34,11 +34,16 @@ export class Paginator {
     }
 
     loadPage(page, param = {}) {
-        param['page'] = page
-        param['per_page'] = this.perPage
+        // take a local, shallow copy of params to prevent
+        // unintended route changes
+        const localParam = { ...param }
+
+        localParam['page'] = page
+        localParam['per_page'] = this.perPage
+
         return axios
             .get(this.url, {
-                params: param,
+                params: localParam,
             })
             .then((response) => {
                 let data = response.data

--- a/Website/ui/src/modules/Sidebar/SideBar.vue
+++ b/Website/ui/src/modules/Sidebar/SideBar.vue
@@ -21,6 +21,7 @@
                     :key="index"
                     :md-expand="menu.sub_menu_items.length !== 0"
                     :to="route(menu.url_slug)"
+                    :exact-path="true"
                 >
                     <md-list-item :md-expand="menu.sub_menu_items.length !== 0">
                         <!-- add icon if icon is defined -->
@@ -49,6 +50,7 @@
                                 v-for="sub in menu.sub_menu_items"
                                 :to="route(sub.url_slug)"
                                 :key="sub.url_slug"
+                                :exact-path="true"
                                 class="sub-menu"
                             >
                                 <md-list-item>
@@ -144,10 +146,16 @@ export default {
             }
         },
         route(routeUrl) {
+            // In the backend/database these are sometimes stored as (for example)
+            // /meters/page/1
+            // but we actually need to convert that to query params
             if (routeUrl !== '') {
                 if (routeUrl.includes('/page/1')) {
                     routeUrl = routeUrl.split('/page/1')[0]
-                    return { path: routeUrl, query: { page: 1, per_page: 15 } }
+                    return {
+                        path: routeUrl,
+                        query: { page: 1, per_page: 15 },
+                    }
                 } else {
                     return { path: routeUrl }
                 }

--- a/Website/ui/src/routes.js
+++ b/Website/ui/src/routes.js
@@ -1,6 +1,8 @@
 import VueRouter from 'vue-router'
 import { exportedRoutes } from './ExportedRoutes'
+
 let routes = exportedRoutes
+
 export default new VueRouter({
     routes,
     linkActiveClass: 'active',

--- a/Website/ui/src/shared/TicketItem.vue
+++ b/Website/ui/src/shared/TicketItem.vue
@@ -200,7 +200,7 @@ export default {
         }
     },
     mounted() {
-        console.log('mounted', this.ticketList)
+        console.log('Mounted this ticket list:', this.ticketList)
     },
     methods: {
         getTimeAgo(date) {


### PR DESCRIPTION
### Problem

This PR tries to address some highlight bugs in the Sidebar. In particular there are two:

1. When manoeuvring to `/tickets` the first time the highlighting doesn't work. Only when the user clicks again on Tickets/List it will appear.

Initial:
![image](https://github.com/EnAccess/micropowermanager/assets/14202480/e62311bf-10ce-4d5e-9387-b0637d7db04c)

Second time:
![image](https://github.com/EnAccess/micropowermanager/assets/14202480/569ace0f-d9d8-4063-bb2c-15a97c9274d3)

2. When users browser through any paginated list, the highlighting breaks as well

After clicking on `>`

![image](https://github.com/EnAccess/micropowermanager/assets/14202480/7d7a28d1-6a8f-4e13-b354-24062344fb2c)

### Solution

The solution for this problem turned out to be pretty entangled into the code base. In short

1. There is a weird, cyclic interaction in `this.term = this.$route.query`. From what I understand the fact that complex objects are passed by reference we are creating a loop in because the Paginator (Vue component) `mounted` we are calling `this.loadPage`, which triggers `this.paginator.loadPage` which in term modifies the query.
2. The second problem was related to handling of query params. This can be resolved be using the `exact-path` which unfortunately isn't well documented but solves the problem