### PR TITLE
Fix veelidate i18n

### DIFF
--- a/Website/ui/package-lock.json
+++ b/Website/ui/package-lock.json
@@ -24,7 +24,6 @@
         "node-gyp": "^6.1.0",
         "popper.js": "^1.16.1",
         "pusher-js": "^4.4.0",
-        "v-validate": "^0.1.4",
         "vee-validate": "^2.0.9",
         "vue": "^2.6.14",
         "vue-airbnb-style-datepicker": "^2.7.1",
@@ -19681,11 +19680,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/v-validate": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/v-validate/-/v-validate-0.1.4.tgz",
-      "integrity": "sha512-cCSUSgAYMYr6TgKbEzcQaKLcDSiWmcwBglsbf84n74mdHMJDBPnOGAEY8LhrjvReQWUILmgkL2fTXjLJnMIhjA=="
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
@@ -36100,11 +36094,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/v-click-outside/-/v-click-outside-2.1.5.tgz",
       "integrity": "sha512-VPNCOTZK6WZy73lcWc+R7IW1uaBFEO3/Csrs5CzWVOdvE30V8Y1+BE/BtTlcEmeDGx0eqdE7bSCg55Jj37PMJg=="
-    },
-    "v-validate": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/v-validate/-/v-validate-0.1.4.tgz",
-      "integrity": "sha512-cCSUSgAYMYr6TgKbEzcQaKLcDSiWmcwBglsbf84n74mdHMJDBPnOGAEY8LhrjvReQWUILmgkL2fTXjLJnMIhjA=="
     },
     "v8-compile-cache": {
       "version": "2.4.0",

--- a/Website/ui/package-lock.json
+++ b/Website/ui/package-lock.json
@@ -24,7 +24,7 @@
         "node-gyp": "^6.1.0",
         "popper.js": "^1.16.1",
         "pusher-js": "^4.4.0",
-        "vee-validate": "^2.0.9",
+        "vee-validate": "^2.2.15",
         "vue": "^2.6.14",
         "vue-airbnb-style-datepicker": "^2.7.1",
         "vue-google-charts": "^0.3.3",

--- a/Website/ui/package.json
+++ b/Website/ui/package.json
@@ -52,7 +52,6 @@
     "node-gyp": "^6.1.0",
     "popper.js": "^1.16.1",
     "pusher-js": "^4.4.0",
-    "v-validate": "^0.1.4",
     "vee-validate": "^2.0.9",
     "vue": "^2.6.14",
     "vue-airbnb-style-datepicker": "^2.7.1",

--- a/Website/ui/package.json
+++ b/Website/ui/package.json
@@ -52,7 +52,7 @@
     "node-gyp": "^6.1.0",
     "popper.js": "^1.16.1",
     "pusher-js": "^4.4.0",
-    "vee-validate": "^2.0.9",
+    "vee-validate": "^2.2.15",
     "vue": "^2.6.14",
     "vue-airbnb-style-datepicker": "^2.7.1",
     "vue-google-charts": "^0.3.3",

--- a/Website/ui/src/bootstrap.js
+++ b/Website/ui/src/bootstrap.js
@@ -24,21 +24,58 @@ import { config } from './config'
 Vue.prototype.appConfig = config
 
 import Vue from 'vue'
+
+/**
+ * Vue Router
+ */
 import VueRouter from 'vue-router'
+
+Vue.use(VueRouter)
+
+/**
+ * Vuex
+ */
 import Vuex from 'vuex'
-import moment from 'moment'
-import Notifications from 'vue-notification'
 
 Vue.use(Vuex)
 window.Vue = Vue
 window.Vuex = Vuex
 
+/**
+ * VeeValidate
+ */
+import i18n from './i18n'
+import VeeValidate from 'vee-validate'
+import enMessages from 'vee-validate/dist/locale/en'
+import frMessages from 'vee-validate/dist/locale/fr'
+
+Vue.use(VeeValidate, {
+    i18n,
+    dictionary: {
+        en: enMessages,
+        fr: frMessages,
+        bu: enMessages, // No burmese error messages available
+    },
+})
+
+/**
+ * VueGoogleCharts
+ */
 import VueGoogleCharts from 'vue-google-charts'
 
 Vue.use(VueGoogleCharts)
 
+/**
+ * moment
+ */
+import moment from 'moment'
+
 window.moment = moment
-Vue.use(VueRouter)
+
+/**
+ * Vue Notification
+ */
+import Notifications from 'vue-notification'
 
 Vue.use(Notifications)
 
@@ -52,6 +89,9 @@ const datepickerOptions = {}
 // make sure we can use it in our components
 Vue.use(AirbnbStyleDatepicker, datepickerOptions)
 
+/**
+ * Reources
+ */
 import { resources } from './resources'
 
 window.resources = resources
@@ -83,6 +123,9 @@ window.onclick = function (e) {
     }
 }
 
+/**
+ * VueGoogleMaps
+ */
 import * as VueGoogleMaps from 'vue2-google-maps'
 
 Vue.use(VueGoogleMaps, {
@@ -90,28 +133,44 @@ Vue.use(VueGoogleMaps, {
         key: 'AIzaSyCiSUjcyWMpV8dAMjIQ-VUaLZZ9NEFIELo',
     },
 })
+
+/**
+ * VueHtml2Canvas
+ */
 import VueHtml2Canvas from 'vue-html2canvas'
 
 Vue.use(VueHtml2Canvas)
 
+/**
+ * VueMaterial
+ */
 import VueMaterial from 'vue-material'
 import 'vue-material/dist/vue-material.min.css'
 import 'vue-material/dist/theme/default.css' // This line here
 Vue.use(VueMaterial)
 
+/**
+ * SidebarComponent
+ */
 import SidebarComponent from '@/modules/Sidebar'
 
 Vue.use(SidebarComponent)
+
+/**
+ * Some SCSS
+ */
 import '../src/assets/sass/mpm.scss'
 
-import VeeValidate from 'vee-validate'
-
-Vue.use(VeeValidate)
-
+/**
+ * Default Layout
+ */
 import Default from './layouts/Default.vue'
 
 Vue.component('default-layout', Default)
 
+/**
+ * VueTelInput
+ */
 import VueTelInput from 'vue-tel-input'
 import 'vue-tel-input/dist/vue-tel-input.css'
 

--- a/Website/ui/src/i18n.js
+++ b/Website/ui/src/i18n.js
@@ -3,14 +3,10 @@ import fr from '../src/assets/locales/fr.json'
 import bu from '../src/assets/locales/bu.json'
 import VueI18n from 'vue-i18n'
 import Vue from 'vue'
-import enMessages from 'vee-validate/dist/locale/en'
-import frMessages from 'vee-validate/dist/locale/fr'
-
-import VeeValidate from 'vee-validate'
 
 Vue.use(VueI18n)
 
-export default new VueI18n({
+const i18n = new VueI18n({
     locale: localStorage.getItem('lang') || 'en',
     messages: {
         en: en,
@@ -19,14 +15,4 @@ export default new VueI18n({
     },
 })
 
-const i18n = new VueI18n()
-i18n.locale = 'en' // set a default locale (without it, it won't work)
-
-Vue.use(VeeValidate, {
-    i18n,
-    dictionary: {
-        en: { messages: enMessages.messages },
-        fr: { messages: frMessages.messages },
-        bu: { messages: enMessages.messages },
-    },
-})
+export default i18n


### PR DESCRIPTION
This PR does three things:

1. Make `bootstrap.js` a bit more easy to understand by adding some grouping.
2. Fix the localisation for validation. Before it was always showing `en` error messages due to `const i18n = new VueI18n()`. Now are re-using the proper `i18n` object.
3. Remove the `v-validate` dependency (which is for `Vue@1` and not used at all) to avoid confusion

Closes: https://github.com/EnAccess/micropowermanager/issues/156
Makes progress on: https://github.com/EnAccess/micropowermanager/issues/154