### PR TITLE
Fix DatePicker dialog closing to early

### DIFF
--- a/Website/ui/src/modules/Agent/AgentDetail.vue
+++ b/Website/ui/src/modules/Agent/AgentDetail.vue
@@ -109,6 +109,7 @@
                                         name="birthDate"
                                         md-immediately
                                         v-model="agent.birthday"
+                                        :md-close-on-blur="false"
                                     >
                                         <label for="birth-date">
                                             Birthday :

--- a/Website/ui/src/modules/Agent/NewAgent.vue
+++ b/Website/ui/src/modules/Agent/NewAgent.vue
@@ -170,9 +170,9 @@
                                 >
                                     <md-datepicker
                                         name="birthDate"
-                                        id="birthDate"
                                         md-immediately
                                         v-model="agentService.agent.birthday"
+                                        :md-close-on-blur="false"
                                     >
                                         <label for="birth-date">
                                             {{ $tc('words.birthday') }} :

--- a/Website/ui/src/modules/Client/AddClientModal.vue
+++ b/Website/ui/src/modules/Client/AddClientModal.vue
@@ -112,9 +112,10 @@
                                 class="md-layout-item md-size-50 md-small-size-100"
                             >
                                 <md-datepicker
-                                    md-immediately
                                     name="birthDate"
+                                    md-immediately
                                     v-model="personService.person.birthDate"
+                                    :md-close-on-blur="false"
                                 >
                                     <label for="birth-date">
                                         {{ $tc('words.birthday') }} :

--- a/Website/ui/src/modules/Client/ClientPersonalData.vue
+++ b/Website/ui/src/modules/Client/ClientPersonalData.vue
@@ -118,9 +118,10 @@
                                 </span>
                             </md-field>
                             <md-datepicker
-                                md-immediately
                                 name="birthDate"
+                                md-immediately
                                 v-model="personService.person.birthDate"
+                                :md-close-on-blur="false"
                             >
                                 <label for="birth-date">
                                     {{ $tc('words.birthday') }} :

--- a/Website/ui/src/modules/Client/Ticket.vue
+++ b/Website/ui/src/modules/Client/Ticket.vue
@@ -41,8 +41,8 @@
                         <md-datepicker
                             name="ticketDueDate"
                             md-immediately
-                            id="ticketDueDate"
                             v-model="newTicket.dueDate"
+                            :md-close-on-blur="false"
                         >
                             <label for="ticketDueDate">
                                 {{ $tc('phrases.dueDate') }}

--- a/Website/ui/src/modules/Dashboard/FinancialOverview.vue
+++ b/Website/ui/src/modules/Dashboard/FinancialOverview.vue
@@ -13,9 +13,10 @@
             <div class="md-layout md-gutter">
                 <div class="md-layout-item md-size-100">
                     <md-datepicker
-                        v-model="period.from"
                         md-immediately
+                        v-model="period.from"
                         v-validate="'required'"
+                        :md-close-on-blur="false"
                     >
                         <label>{{ $tc('phrases.fromDate') }}</label>
                     </md-datepicker>
@@ -25,9 +26,10 @@
                 </div>
                 <div class="md-layout-item md-size-100">
                     <md-datepicker
-                        v-model="period.to"
                         md-immediately
+                        v-model="period.to"
                         v-validate="'required'"
+                        :md-close-on-blur="false"
                     >
                         <label>{{ $tc('phrases.toDate') }}</label>
                     </md-datepicker>

--- a/Website/ui/src/modules/Maintenance/Maintenance.vue
+++ b/Website/ui/src/modules/Maintenance/Maintenance.vue
@@ -160,10 +160,11 @@
                             >
                                 <div>
                                     <md-datepicker
-                                        v-model="maintenanceData.dueDate"
                                         :name="$tc('words.date')"
-                                        v-validate="'required'"
                                         md-immediately
+                                        v-model="maintenanceData.dueDate"
+                                        v-validate="'required'"
+                                        :md-close-on-blur="false"
                                     >
                                         <label>
                                             {{ $tc('phrases.dueDate') }}

--- a/Website/ui/src/modules/Meter/Readings.vue
+++ b/Website/ui/src/modules/Meter/Readings.vue
@@ -13,9 +13,10 @@
             <div class="md-layout md-gutter">
                 <div class="md-layout-item md-size-100">
                     <md-datepicker
-                        v-model="dates.dateOne"
                         md-immediately
+                        v-model="dates.dateOne"
                         v-validate="'required'"
+                        :md-close-on-blur="false"
                     >
                         <label>{{ $tc('phrases.fromDate') }}</label>
                     </md-datepicker>
@@ -25,9 +26,10 @@
                 </div>
                 <div class="md-layout-item md-size-100">
                     <md-datepicker
-                        v-model="dates.dateTwo"
                         md-immediately
+                        v-model="dates.dateTwo"
                         v-validate="'required'"
+                        :md-close-on-blur="false"
                     >
                         <label>{{ $tc('phrases.toDate') }}</label>
                     </md-datepicker>

--- a/Website/ui/src/modules/MiniGrid/Dashboard.vue
+++ b/Website/ui/src/modules/MiniGrid/Dashboard.vue
@@ -62,9 +62,10 @@
                                 <div class="md-layout md-gutter">
                                     <div class="md-layout-item md-size-100">
                                         <md-datepicker
-                                            v-model="period.from"
                                             md-immediately
+                                            v-model="period.from"
                                             v-validate="'required'"
+                                            :md-close-on-blur="false"
                                         >
                                             <label>
                                                 {{ $tc('phrases.fromDate') }}
@@ -80,9 +81,10 @@
                                     </div>
                                     <div class="md-layout-item md-size-100">
                                         <md-datepicker
-                                            v-model="period.to"
                                             md-immediately
+                                            v-model="period.to"
                                             v-validate="'required'"
+                                            :md-close-on-blur="false"
                                         >
                                             <label>
                                                 {{ $tc('phrases.toDate') }}

--- a/Website/ui/src/modules/Target/NewTarget.vue
+++ b/Website/ui/src/modules/Target/NewTarget.vue
@@ -85,10 +85,10 @@
                                 ),
                             }"
                             :name="$tc('phrases.validUntil')"
-                            v-validate.initial="'required'"
-                            :md-model-type="String"
                             md-immediately
                             v-model="targetValidUntil"
+                            v-validate.initial="'required'"
+                            :md-close-on-blur="false"
                         >
                             <label>{{ $tc('phrases.validUntil') }}</label>
                             <span class="md-error">

--- a/Website/ui/src/modules/Transactions/FilterTransaction.vue
+++ b/Website/ui/src/modules/Transactions/FilterTransaction.vue
@@ -107,9 +107,9 @@
                         class="md-layout-item md-xlarge-size-100 md-large-size-100 md-medium-size-100 md-small-size-100 md-xsmall-size-100"
                     >
                         <md-datepicker
-                            v-model="filterFrom"
                             md-immediately
-                            :md-model-type="String"
+                            v-model="filterFrom"
+                            :md-close-on-blur="false"
                         >
                             <label>{{ $tc('phrases.fromDate') }}</label>
                         </md-datepicker>
@@ -119,9 +119,9 @@
                         class="md-layout-item md-xlarge-size-100 md-large-size-100 md-medium-size-100 md-small-size-100 md-xsmall-size-100"
                     >
                         <md-datepicker
-                            v-model="filterTo"
                             md-immediately
-                            :md-model-type="String"
+                            v-model="filterTo"
+                            :md-close-on-blur="false"
                         >
                             <label>{{ $tc('phrases.toDate') }}</label>
                         </md-datepicker>


### PR DESCRIPTION
As a workaround we can set

```
:md-close-on-blur="false"
```

to keep the DatePicker dialog open.

More information here: https://github.com/vuematerial/vue-material/issues/2396

Closes: #168 