### PR TITLE
Add Code Style composer scripts for entire repo

### DIFF
--- a/.github/workflows/php_linter.yml
+++ b/.github/workflows/php_linter.yml
@@ -32,9 +32,15 @@ jobs:
           composer install --no-interaction --prefer-dist
         working-directory: ./Website/htdocs/mpmanager
 
-      - name: Run PHP-CS-Fixer
+      - name: Run PHP-CS-Fixer (src)
         run: composer run php-cs-fixer-check
         working-directory: ./Website/htdocs/mpmanager
+
+        # Temporary check for Code Style in entire code base
+      - name: Run PHP-CS-Fixer (all)
+        run: composer run php-cs-fixer-check-all
+        working-directory: ./Website/htdocs/mpmanager
+        continue-on-error: true
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyze --error-format=table  app/Http app/Services app/Models/ app/Events app/Listeners app/Misc app/modules --memory-limit=2G  --level=1

--- a/Website/htdocs/mpmanager/composer.json
+++ b/Website/htdocs/mpmanager/composer.json
@@ -102,6 +102,8 @@
     "lint": "find . -name \\*.php -not -path './lib/composer/*' -not -path './vendor/*' -not -path './build/.phan/*' -exec php -l \"{}\" \\;",
     "php-cs-fixer-fix": "php-cs-fixer fix --diff app/",
     "php-cs-fixer-check": "php-cs-fixer check --diff app/",
+    "php-cs-fixer-fix-all": "php-cs-fixer fix --diff",
+    "php-cs-fixer-check-all": "php-cs-fixer check --diff",
     "analyze": "phpstan analyse --memory-limit=2G --no-progress --level=max --configuration=phpstan.neon --autoload-file=vendor/autoload.php --error-format=table app/ packages/ tests/",
     "psalm-check": "psalm app/"
   }


### PR DESCRIPTION
Makes progress on: #107 

In a first step we are adding Composer Scripts and Github Actions job to check the Code Style in the entire PHP code base.