### PR TITLE
Simplify`SideBar` store management

### DIFF
--- a/Website/ui/src/ExportedRoutes.js
+++ b/Website/ui/src/ExportedRoutes.js
@@ -773,145 +773,28 @@ export const exportedRoutes = [
         ],
     },
     {
-        path: '/calin-meters',
-        component: ChildRouteWrapper,
+        path: '/e-bikes',
+        component: EBikeList,
         meta: {
+            layout: 'default',
             sidebar: {
                 enabled: true,
-                name: 'Calin Meter',
-                icon: 'bolt',
+                name: 'E-Bikes',
+                icon: 'electric_bike',
             },
         },
-        children: [
-            {
-                path: 'calin-overview',
-                component: CalinMeterOverview,
-                meta: {
-                    layout: 'default',
-                    sidebar: {
-                        enabled: true,
-                        name: 'Overview',
-                    },
-                },
-            },
-        ],
     },
-    {
-        path: '/calin-smart-meters',
-        component: ChildRouteWrapper,
-        meta: {
-            sidebar: {
-                enabled_by_mpm_plugin_id: 4,
-                name: 'CalinSmart Meter',
-                icon: 'bolt',
-            },
-        },
-        children: [
-            {
-                path: 'calin-smart-overview',
-                component: CalinSmartMeterOverview,
-                meta: {
-                    layout: 'default',
-                    sidebar: {
-                        enabled: true,
-                        name: 'Overview',
-                    },
-                },
-            },
-        ],
-    },
-    {
-        path: '/kelin-meters',
-        component: ChildRouteWrapper,
-        meta: {
-            sidebar: {
-                enabled: true,
-                name: 'Kelin Meter',
-                icon: 'bolt',
-            },
-        },
-        children: [
-            {
-                path: 'kelin-overview',
-                component: KelinMeterOverview,
-                meta: {
-                    layout: 'default',
-                    sidebar: {
-                        enabled: true,
-                        name: 'Overview',
-                    },
-                },
-            },
-            {
-                path: 'kelin-customer',
-                component: KelinMeterCustomerList,
-                meta: {
-                    layout: 'default',
-                    sidebar: {
-                        enabled: true,
-                        name: 'Customers',
-                    },
-                },
-            },
-            {
-                path: 'kelin-setting',
-                component: KelinMeterSettings,
-                meta: {
-                    layout: 'default',
-                    sidebar: {
-                        enabled: true,
-                        name: 'Settings',
-                    },
-                },
-            },
-            {
-                path: 'kelin-meter',
-                component: ChildRouteWrapper,
-                meta: {
-                    sidebar: {
-                        enabled: true,
-                        name: 'Meters',
-                    },
-                },
-                children: [
-                    {
-                        path: '',
-                        component: KelinMeterList,
-                        meta: {
-                            layout: 'default',
-                        },
-                    },
-                    {
-                        path: 'status/:meter',
-                        component: KelinMeterStatus,
-                        meta: {
-                            layout: 'default',
-                        },
-                    },
-                    {
-                        path: 'daily-consumptions/:meter',
-                        component: KelinMeterConsumptionDaily,
-                        meta: {
-                            layout: 'default',
-                        },
-                    },
-                    {
-                        path: 'minutely-consumptions/:meter',
-                        component: KelinMeterConsumptionMinutely,
-                        meta: {
-                            layout: 'default',
-                        },
-                    },
-                ],
-            },
-        ],
-    },
+    /**
+     *
+     * PLUGIN ROUTES
+     *
+     */
     {
         path: '/spark-meters',
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 1,
                 name: 'Spark Meter',
                 icon: 'bolt',
             },
@@ -1098,11 +981,145 @@ export const exportedRoutes = [
         ],
     },
     {
+        path: '/calin-meters',
+        component: ChildRouteWrapper,
+        meta: {
+            sidebar: {
+                enabled_by_mpm_plugin_id: 3,
+                name: 'Calin Meter',
+                icon: 'bolt',
+            },
+        },
+        children: [
+            {
+                path: 'calin-overview',
+                component: CalinMeterOverview,
+                meta: {
+                    layout: 'default',
+                    sidebar: {
+                        enabled: true,
+                        name: 'Overview',
+                    },
+                },
+            },
+        ],
+    },
+    {
+        path: '/calin-smart-meters',
+        component: ChildRouteWrapper,
+        meta: {
+            sidebar: {
+                enabled_by_mpm_plugin_id: 4,
+                name: 'CalinSmart Meter',
+                icon: 'bolt',
+            },
+        },
+        children: [
+            {
+                path: 'calin-smart-overview',
+                component: CalinSmartMeterOverview,
+                meta: {
+                    layout: 'default',
+                    sidebar: {
+                        enabled: true,
+                        name: 'Overview',
+                    },
+                },
+            },
+        ],
+    },
+    {
+        path: '/kelin-meters',
+        component: ChildRouteWrapper,
+        meta: {
+            sidebar: {
+                enabled_by_mpm_plugin_id: 5,
+                name: 'Kelin Meter',
+                icon: 'bolt',
+            },
+        },
+        children: [
+            {
+                path: 'kelin-overview',
+                component: KelinMeterOverview,
+                meta: {
+                    layout: 'default',
+                    sidebar: {
+                        enabled: true,
+                        name: 'Overview',
+                    },
+                },
+            },
+            {
+                path: 'kelin-customer',
+                component: KelinMeterCustomerList,
+                meta: {
+                    layout: 'default',
+                    sidebar: {
+                        enabled: true,
+                        name: 'Customers',
+                    },
+                },
+            },
+            {
+                path: 'kelin-setting',
+                component: KelinMeterSettings,
+                meta: {
+                    layout: 'default',
+                    sidebar: {
+                        enabled: true,
+                        name: 'Settings',
+                    },
+                },
+            },
+            {
+                path: 'kelin-meter',
+                component: ChildRouteWrapper,
+                meta: {
+                    sidebar: {
+                        enabled: true,
+                        name: 'Meters',
+                    },
+                },
+                children: [
+                    {
+                        path: '',
+                        component: KelinMeterList,
+                        meta: {
+                            layout: 'default',
+                        },
+                    },
+                    {
+                        path: 'status/:meter',
+                        component: KelinMeterStatus,
+                        meta: {
+                            layout: 'default',
+                        },
+                    },
+                    {
+                        path: 'daily-consumptions/:meter',
+                        component: KelinMeterConsumptionDaily,
+                        meta: {
+                            layout: 'default',
+                        },
+                    },
+                    {
+                        path: 'minutely-consumptions/:meter',
+                        component: KelinMeterConsumptionMinutely,
+                        meta: {
+                            layout: 'default',
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+    {
         path: '/stron-meters',
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 6,
                 name: 'Stron Meter',
                 icon: 'bolt',
             },
@@ -1122,11 +1139,37 @@ export const exportedRoutes = [
         ],
     },
     {
+        path: '/swifta-payment',
+        component: ChildRouteWrapper,
+        meta: {
+            sidebar: {
+                enabled_by_mpm_plugin_id: 7,
+                name: 'Swifta',
+                icon: 'money',
+            },
+        },
+        children: [
+            {
+                path: 'swifta-payment-overview',
+                component: SwiftaOverview,
+                meta: {
+                    layout: 'default',
+                    sidebar: {
+                        enabled: true,
+                        name: 'Overview',
+                    },
+                },
+            },
+        ],
+    },
+    // FIXME: Where is mpm_plugin_id = 8?
+    // Seems to be a plugin called "MesombPayment"
+    {
         path: '/bulk-registration/bulk-registration',
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 9,
                 name: 'Bulk Registration',
                 icon: 'upload_file',
             },
@@ -1146,7 +1189,7 @@ export const exportedRoutes = [
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 10,
                 name: 'Viber Messaging',
                 icon: 'message',
             },
@@ -1170,7 +1213,7 @@ export const exportedRoutes = [
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 11,
                 name: 'WaveMoney',
                 icon: 'money',
             },
@@ -1212,7 +1255,7 @@ export const exportedRoutes = [
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 12,
                 name: 'MicroStar Meter',
                 icon: 'bolt',
             },
@@ -1231,36 +1274,13 @@ export const exportedRoutes = [
             },
         ],
     },
-    {
-        path: '/swifta-payment',
-        component: ChildRouteWrapper,
-        meta: {
-            sidebar: {
-                enabled: true,
-                name: 'Swifta',
-                icon: 'money',
-            },
-        },
-        children: [
-            {
-                path: 'swifta-payment-overview',
-                component: SwiftaOverview,
-                meta: {
-                    layout: 'default',
-                    sidebar: {
-                        enabled: true,
-                        name: 'Overview',
-                    },
-                },
-            },
-        ],
-    },
+
     {
         path: '/sun-king-shs',
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 13,
                 name: 'SunKing SHS',
                 icon: 'bolt',
             },
@@ -1284,7 +1304,7 @@ export const exportedRoutes = [
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 14,
                 name: 'GomeLong Meter',
                 icon: 'bolt',
             },
@@ -1309,21 +1329,9 @@ export const exportedRoutes = [
         meta: {
             layout: 'default',
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 15,
                 name: 'Wavecom Payment Provider',
                 icon: 'upload_file',
-            },
-        },
-    },
-    {
-        path: '/e-bikes',
-        component: EBikeList,
-        meta: {
-            layout: 'default',
-            sidebar: {
-                enabled: true,
-                name: 'E-Bikes',
-                icon: 'electric_bike',
             },
         },
     },
@@ -1333,7 +1341,7 @@ export const exportedRoutes = [
         meta: {
             layout: 'default',
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 16,
                 name: 'Daly BMS',
                 icon: 'charging_station',
             },
@@ -1358,7 +1366,7 @@ export const exportedRoutes = [
         meta: {
             layout: 'default',
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 17,
                 name: 'Angaza SHS',
                 icon: 'bolt',
             },

--- a/Website/ui/src/ExportedRoutes.js
+++ b/Website/ui/src/ExportedRoutes.js
@@ -801,7 +801,7 @@ export const exportedRoutes = [
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 4,
                 name: 'CalinSmart Meter',
                 icon: 'bolt',
             },
@@ -1016,7 +1016,7 @@ export const exportedRoutes = [
         component: ChildRouteWrapper,
         meta: {
             sidebar: {
-                enabled: true,
+                enabled_by_mpm_plugin_id: 2,
                 name: 'SteamaCo Meter',
                 icon: 'bolt',
             },

--- a/Website/ui/src/modules/Register/Register.vue
+++ b/Website/ui/src/modules/Register/Register.vue
@@ -666,14 +666,10 @@ export default {
             )
             try {
                 this.loading = true
-                let response = await this.companyService.register(
-                    this.companyForm,
-                )
+                await this.companyService.register(this.companyForm)
                 this.loading = false
-                await this.$store.dispatch(
-                    'settings/setSidebar',
-                    response.sidebarData,
-                )
+
+                await this.$store.dispatch('settings/fetchPlugins')
                 const email = this.companyForm.user.email
                 const password = this.companyForm.user.password
 

--- a/Website/ui/src/modules/Settings/PluginSettings.vue
+++ b/Website/ui/src/modules/Settings/PluginSettings.vue
@@ -33,7 +33,6 @@
 <script>
 import { MpmPluginService } from '@/services/MpmPluginService'
 import { PluginService } from '@/services/PluginService'
-import { EventBus } from '@/shared/eventbus'
 
 export default {
     name: 'PluginSettings',
@@ -55,6 +54,9 @@ export default {
             required: true,
         },
     },
+    async created() {
+        await this.$store.dispatch('settings/fetchPlugins')
+    },
     computed: {
         enrichedPlugins: function () {
             return this.plugins.map((plugin) => ({
@@ -72,7 +74,7 @@ export default {
             this.progressing = true
             try {
                 await this.pluginService.updatePlugin(plugin)
-                EventBus.$emit('setSidebar')
+                await this.$store.dispatch('settings/fetchPlugins')
                 this.alertNotify('success', 'Plugin updated successfully')
             } catch (e) {
                 this.switching = false

--- a/Website/ui/src/modules/Sidebar/SideBar.vue
+++ b/Website/ui/src/modules/Sidebar/SideBar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="sidebar" :data-color="sidebarItemColor" :style="sidebarStyle">
+    <div class="sidebar" :data-color="sidebarItemColor">
         <div class="logo">
             <div class="brand-column">
                 <img class="logo" alt="logo" :src="imgLogo" />
@@ -27,7 +27,7 @@
                         <!-- If the route has no children, then it should be a clickable menu item -->
                         <router-link
                             v-if="!hasSubMenu(menu)"
-                            :to="route(menu.path)"
+                            :to="menu.path"
                             :exact-path="true"
                             :key="'menu' + menu.path"
                         >
@@ -72,11 +72,7 @@
                                     <router-link
                                         v-for="sub in menu.children"
                                         :key="sub.path"
-                                        :to="
-                                            route(
-                                                subMenuUrl(menu.path, sub.path),
-                                            )
-                                        "
+                                        :to="subMenuUrl(menu.path, sub.path)"
                                         class="sub-menu"
                                         :exact-path="true"
                                     >
@@ -139,8 +135,6 @@ export default {
 
     data() {
         return {
-            show_extender: false,
-            admin: null,
             translateItem: translateItem,
             routes: this.$router.options.routes,
         }
@@ -163,7 +157,6 @@ export default {
             type: String,
             default: 'green',
         },
-
         autoClose: {
             type: Boolean,
             default: true,
@@ -199,28 +192,9 @@ export default {
                 return this.$tc('menu.' + name)
             }
         },
-        route(routeUrl) {
-            // In the backend/database these are sometimes stored as (for example)
-            // /meters/page/1
-            // but we actually need to convert that to query params
-            if (routeUrl !== '') {
-                if (routeUrl.includes('/page/1')) {
-                    routeUrl = routeUrl.split('/page/1')[0]
-                    return {
-                        path: routeUrl,
-                        query: { page: 1, per_page: 15 },
-                    }
-                } else {
-                    return { path: routeUrl }
-                }
-            }
-        },
     },
     computed: {
         ...mapGetters('settings', ['getEnabledPlugins']),
-        adminName() {
-            return this.$store.getters['auth/getAuthenticateUser'].name
-        },
         sidebarStyle() {
             return {
                 background: '#2b2b2b !important',
@@ -230,6 +204,10 @@ export default {
 }
 </script>
 <style>
+.sidebar {
+    background: #2b2b2b;
+}
+
 .brand-column {
     display: -webkit-box;
     display: -webkit-flex;
@@ -303,12 +281,6 @@ export default {
     color: #f5e8e8 !important;
 }
 
-.sidebar-layout {
-    position: absolute;
-    height: 100%;
-    width: 100%;
-}
-
 .icon-box {
     margin-right: 10px !important;
     width: 25px !important;
@@ -321,20 +293,6 @@ export default {
 
 .sub-menu {
     width: 100% !important;
-}
-
-.c-gray {
-    color: gray;
-}
-
-.app-style {
-    width: calc(100% / 12 * 2);
-    position: fixed;
-}
-
-.drawer-style {
-    background-color: #2b2b2b !important;
-    height: 100vh;
 }
 
 .p-15 {

--- a/Website/ui/src/store/modules/settings.js
+++ b/Website/ui/src/store/modules/settings.js
@@ -2,19 +2,20 @@ import { TicketSettingsService } from '@/services/TicketSettingsService'
 import { MapSettingsService } from '@/services/MapSettingsService'
 import { MainSettingsService } from '@/services/MainSettingsService'
 import i18n from '../../i18n'
-import { SidebarService } from '@/services/SidebarService'
+import { PluginService } from '@/services/PluginService'
+
+const serviceMap = new MapSettingsService()
+const serviceMain = new MainSettingsService()
+const serviceTicket = new TicketSettingsService()
+const servicePlugin = new PluginService()
 
 export const namespaced = true
 
 export const state = {
-    serviceMap: new MapSettingsService(),
-    serviceMain: new MainSettingsService(),
-    serviceTicket: new TicketSettingsService(),
-    serviceSidebar: new SidebarService(),
     mainSettings: {},
     ticketSettings: {},
     mapSettings: {},
-    sidebar: [],
+    plugins: [],
 }
 export const mutations = {
     FETCH_MAIN_SETTINGS(state, payload) {
@@ -27,8 +28,8 @@ export const mutations = {
     FETCH_TICKET_SETTINGS(state, payload) {
         state.ticketSettings = payload
     },
-    SET_SIDEBAR(state, payload) {
-        state.sidebar = payload
+    FETCH_PLUGINS(state, payload) {
+        state.plugins = payload
     },
 }
 export const actions = {
@@ -39,7 +40,7 @@ export const actions = {
     },
     setMainSettings({ commit }) {
         return new Promise((resolve, reject) => {
-            state.serviceMain
+            serviceMain
                 .list()
                 .then((res) => {
                     commit('FETCH_MAIN_SETTINGS', res)
@@ -52,7 +53,7 @@ export const actions = {
     },
     setMapSettings({ commit }) {
         return new Promise((resolve, reject) => {
-            state.serviceMap
+            serviceMap
                 .list()
                 .then((res) => {
                     commit('FETCH_MAP_SETTINGS', res)
@@ -65,7 +66,7 @@ export const actions = {
     },
     setTicketSettings({ commit }) {
         return new Promise((resolve, reject) => {
-            state.serviceTicket
+            serviceTicket
                 .list()
                 .then((res) => {
                     commit('FETCH_TICKET_SETTINGS', res)
@@ -76,22 +77,18 @@ export const actions = {
                 })
         })
     },
-    setSidebar({ commit }, sidebar = null) {
-        if (sidebar) {
-            commit('SET_SIDEBAR', sidebar)
-        } else {
-            return new Promise((resolve, reject) => {
-                state.serviceSidebar
-                    .list()
-                    .then((res) => {
-                        commit('SET_SIDEBAR', res)
-                        resolve(res)
-                    })
-                    .catch((e) => {
-                        reject(e)
-                    })
-            })
-        }
+    fetchPlugins({ commit }) {
+        return new Promise((resolve, reject) => {
+            servicePlugin
+                .getPlugins()
+                .then((res) => {
+                    commit('FETCH_PLUGINS', res)
+                    resolve(res)
+                })
+                .catch((e) => {
+                    reject(e)
+                })
+        })
     },
 }
 
@@ -105,8 +102,8 @@ export const getters = {
     getTicketSettings: (state) => {
         return state.ticketSettings
     },
-    mainSettingsService: (state) => state.serviceMain,
-    mapSettingsService: (state) => state.serviceMap,
-    ticketSettingsService: (state) => state.serviceTicket,
-    getSidebar: (state) => state.sidebar,
+    getEnabledPlugins: (state) =>
+        state.plugins
+            .filter((item) => item.status === 1)
+            .map((item) => item.mpm_plugin_id),
 }


### PR DESCRIPTION
Makes progress on: #122
Fixes: #181

Using event's here is pointless. The store already know when it's updated or not. Pulling in the active plugins store into a computed property.

Currently, we rely on `mpm_plugin_id` to be consistent across multiple installations of MPM. To be confirmed if this is a correct assumption,

Also clean up some leftovers.