### PR TITLE
Fix additional user creation

### DIFF
--- a/Website/htdocs/mpmanager/app/Http/Controllers/UserController.php
+++ b/Website/htdocs/mpmanager/app/Http/Controllers/UserController.php
@@ -29,7 +29,7 @@ class UserController extends Controller
     public function store(CreateAdminRequest $request)
     {
         $user = $this->userService->create($request->only(['name', 'password', 'email']));
-        $companyDatabase = $this->companyDatabaseService->getById($user->getCompanyId());
+        $companyDatabase = $this->companyDatabaseService->findByCompanyId($user->getCompanyId());
         $databaseProxyData = [
             'email' => $user->getEmail(),
             'fk_company_id' => $user->getCompanyId(),

--- a/Website/htdocs/mpmanager/app/Models/CompanyDatabase.php
+++ b/Website/htdocs/mpmanager/app/Models/CompanyDatabase.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use App\Models\Base\BaseModelCore;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int $id;
@@ -19,9 +19,9 @@ class CompanyDatabase extends BaseModelCore
     public const COL_DATABASE_NAME = 'database_name';
     public const COL_COMPANY_ID = 'company_id';
 
-    public function company(): HasOne
+    public function company(): BelongsTo
     {
-        return $this->HasOne(Company::class);
+        return $this->belongsTo(Company::class);
     }
 
     public function findByCompanyId(int $companyId): CompanyDatabase


### PR DESCRIPTION
Currently additional user creation fails. The User object in tenant db is created but the duplicated entry in DatabaseProxy is not. Hence the user cannot log in.

This PR fixes the issue.