### PR TITLE
Fix database proxy hardcode

### DIFF
--- a/Website/htdocs/mpmanager/app/Console/Commands/ModelShowTenant.php
+++ b/Website/htdocs/mpmanager/app/Console/Commands/ModelShowTenant.php
@@ -21,7 +21,7 @@ class ModelShowTenant extends Command
      *
      * @var string
      */
-    protected $description = 'Show information about an Eloquent model on provided tenant database';
+    protected $description = 'Show information about an Eloquent model on provided tenant database. This command requires demo data to be loaded.';
 
     /**
      * Create a new command instance.

--- a/Website/htdocs/mpmanager/app/Console/Commands/ModelShowTenant.php
+++ b/Website/htdocs/mpmanager/app/Console/Commands/ModelShowTenant.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use App\Utils\DummyCompany;
 use Illuminate\Console\Command;
 use MPM\DatabaseProxy\DatabaseProxyManagerService;
 

--- a/Website/htdocs/mpmanager/app/Console/Commands/ModelShowTenant.php
+++ b/Website/htdocs/mpmanager/app/Console/Commands/ModelShowTenant.php
@@ -29,9 +29,8 @@ class ModelShowTenant extends Command
      * @return void
      */
     public function __construct(
-        private DatabaseProxyManagerService $databaseProxyManagerService
+        private DatabaseProxyManagerService $databaseProxyManagerService,
     ) {
-        $this->databaseProxyManagerService->buildDatabaseConnectionByCompanyId(DummyCompany::DUMMY_COMPANY_ID);
         parent::__construct();
     }
 
@@ -42,6 +41,8 @@ class ModelShowTenant extends Command
      */
     public function handle()
     {
+        $this->databaseProxyManagerService->buildDatabaseConnectionDummyCompany();
+
         $this->call('model:show', [
             'model' => $this->argument('model'),
         ]);

--- a/Website/htdocs/mpmanager/app/Services/CompanyDatabaseService.php
+++ b/Website/htdocs/mpmanager/app/Services/CompanyDatabaseService.php
@@ -16,7 +16,7 @@ class CompanyDatabaseService implements IBaseService
 {
     public function __construct(
         private CompanyDatabase $companyDatabase,
-        private DatabaseProxyManagerService $databaseProxyManagerService
+        private DatabaseProxyManagerService $databaseProxyManagerService,
     ) {
     }
 

--- a/Website/htdocs/mpmanager/app/Services/CompanyService.php
+++ b/Website/htdocs/mpmanager/app/Services/CompanyService.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 class CompanyService implements IBaseService
 {
     public function __construct(
-        private Company $company
+        private Company $company,
     ) {
     }
 
@@ -52,6 +52,6 @@ class CompanyService implements IBaseService
 
     public function getAll(?int $limit = null): Collection
     {
-        throw new \Exception('Method getAll() not yet implemented.');
+        return $this->company->newQuery()->get();
     }
 }

--- a/Website/htdocs/mpmanager/app/modules/DatabaseProxy/DatabaseProxyManagerService.php
+++ b/Website/htdocs/mpmanager/app/modules/DatabaseProxy/DatabaseProxyManagerService.php
@@ -6,6 +6,7 @@ namespace MPM\DatabaseProxy;
 
 use App\Models\CompanyDatabase;
 use App\Models\DatabaseProxy;
+use App\Utils\DummyCompany;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -14,7 +15,7 @@ class DatabaseProxyManagerService
     public function __construct(
         private DatabaseProxy $databaseProxy,
         private DatabaseManager $databaseManager,
-        private CompanyDatabase $companyDatabase
+        private CompanyDatabase $companyDatabase,
     ) {
     }
 
@@ -36,9 +37,9 @@ class DatabaseProxyManagerService
         return $this->companyDatabase->newQuery();
     }
 
-    public function buildDatabaseConnectionByCompanyId(int $company_id): void
+    public function buildDatabaseConnectionDummyCompany(): void
     {
-        $this->buildDatabaseConnection('DummyCompany_1');
+        $this->buildDatabaseConnection(DummyCompany::DUMMY_COMPANY_DATABASE_NAME);
     }
 
     private function buildDatabaseConnection(string $databaseName): void

--- a/Website/htdocs/mpmanager/database/seeders/ClusterSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/ClusterSeeder.php
@@ -7,7 +7,6 @@ use App\Models\Cluster;
 use App\Models\GeographicalInformation;
 use App\Models\MiniGrid;
 use App\Models\User;
-use App\Utils\DummyCompany;
 use Illuminate\Database\Seeder;
 use MPM\DatabaseProxy\DatabaseProxyManagerService;
 
@@ -16,7 +15,7 @@ class ClusterSeeder extends Seeder
     public function __construct(
         private DatabaseProxyManagerService $databaseProxyManagerService,
     ) {
-        $this->databaseProxyManagerService->buildDatabaseConnectionByCompanyId(DummyCompany::DUMMY_COMPANY_ID);
+        $this->databaseProxyManagerService->buildDatabaseConnectionDummyCompany();
     }
 
     /**

--- a/Website/htdocs/mpmanager/database/seeders/CustomerSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/CustomerSeeder.php
@@ -6,7 +6,6 @@ use App\Models\Address\Address;
 use App\Models\City;
 use App\Models\GeographicalInformation;
 use App\Models\Person\Person;
-use App\Utils\DummyCompany;
 use Illuminate\Database\Seeder;
 use MPM\DatabaseProxy\DatabaseProxyManagerService;
 
@@ -15,7 +14,7 @@ class CustomerSeeder extends Seeder
     public function __construct(
         private DatabaseProxyManagerService $databaseProxyManagerService,
     ) {
-        $this->databaseProxyManagerService->buildDatabaseConnectionByCompanyId(DummyCompany::DUMMY_COMPANY_ID);
+        $this->databaseProxyManagerService->buildDatabaseConnectionDummyCompany();
     }
 
     /**

--- a/Website/htdocs/mpmanager/database/seeders/DeviceSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/DeviceSeeder.php
@@ -13,7 +13,6 @@ use App\Models\Meter\Meter;
 use App\Models\Meter\MeterTariff;
 use App\Models\Meter\MeterType;
 use App\Models\Person\Person;
-use App\Utils\DummyCompany;
 use Illuminate\Database\Seeder;
 use MPM\DatabaseProxy\DatabaseProxyManagerService;
 
@@ -22,7 +21,7 @@ class DeviceSeeder extends Seeder
     public function __construct(
         private DatabaseProxyManagerService $databaseProxyManagerService,
     ) {
-        $this->databaseProxyManagerService->buildDatabaseConnectionByCompanyId(DummyCompany::DUMMY_COMPANY_ID);
+        $this->databaseProxyManagerService->buildDatabaseConnectionDummyCompany();
     }
 
     /**

--- a/Website/htdocs/mpmanager/database/seeders/TenantSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/TenantSeeder.php
@@ -42,6 +42,13 @@ class TenantSeeder extends Seeder
      */
     public function run()
     {
+        // Only proceed if database is empty.
+        // In some seeders we rely on the DummyCompany having id=1.
+        $companies = $this->companyService->getAll();
+        if ($companies->isNotEmpty()) {
+            throw new \Exception('There are already companies configured in MicroPowerManager. Demo data should only be loaded into an empty database. If you wish to reset existing setup with only Demo data, run `artisan migrate-tenant:drop-demo-company` and try again.');
+        }
+
         // Create Company and CompanyDatabase
         $company = $this->companyService->create(DUMMY_COMPANY_DATA);
 

--- a/Website/htdocs/mpmanager/database/seeders/TenantSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/TenantSeeder.php
@@ -31,7 +31,7 @@ class TenantSeeder extends Seeder
         private CompanyService $companyService,
         private UserService $userService,
         private DatabaseProxyManagerService $databaseProxyManagerService,
-        private MainSettingsService $mainSettingsService
+        private MainSettingsService $mainSettingsService,
     ) {
     }
 

--- a/Website/htdocs/mpmanager/database/seeders/TicketSeeder.php
+++ b/Website/htdocs/mpmanager/database/seeders/TicketSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Utils\DummyCompany;
 use Illuminate\Database\Seeder;
 use Inensus\Ticket\Models\TicketCategory;
 use MPM\DatabaseProxy\DatabaseProxyManagerService;
@@ -12,7 +11,7 @@ class TicketSeeder extends Seeder
     public function __construct(
         private DatabaseProxyManagerService $databaseProxyManagerService,
     ) {
-        $this->databaseProxyManagerService->buildDatabaseConnectionByCompanyId(DummyCompany::DUMMY_COMPANY_ID);
+        $this->databaseProxyManagerService->buildDatabaseConnectionDummyCompany();
     }
 
     /**


### PR DESCRIPTION
Calling `buildDatabaseConnectionByCompanyId` in the constructor fails Company registration because the company will always be set to `DummyCompany_1`. This is because we are using Artisan in the company creation process and this (seemingly unrelated) constructor messes things up.

Also, cleaning up some minor things.