### PR TITLE
 fix: Sold Appliance Details not clickable in User/Customer View #126

### DIFF
--- a/src/frontend/src/modules/Client/Appliances/SoldAppliancesList.vue
+++ b/src/frontend/src/modules/Client/Appliances/SoldAppliancesList.vue
@@ -38,14 +38,6 @@
           </md-table-cell>
           <md-table-cell md-label="Rates" md-sort-by="rate_count">
             {{ item.rate_count }}
-            <div
-              :class="index === -999 ? 'text-danger' : 'text-success'"
-              style="cursor: pointer; display: inline-block"
-            
-            >
-              <md-icon>remove_red_eye</md-icon>
-              {{ $tc("words.detail", 1) }}
-            </div>
           </md-table-cell>
         </md-table-row>
       </md-table>

--- a/src/frontend/src/modules/Client/Appliances/SoldAppliancesList.vue
+++ b/src/frontend/src/modules/Client/Appliances/SoldAppliancesList.vue
@@ -24,6 +24,8 @@
           v-for="(item, index) in soldAppliancesList"
           :key="index"
           :class="selectedApplianceId === item.id ? 'selected-row' : ''"
+           @click="showDetails(soldAppliancesList[index].id)"
+
         >
           <md-table-cell md-label="Name" md-sort-by="name">
             {{ item.asset.name }}
@@ -39,7 +41,7 @@
             <div
               :class="index === -999 ? 'text-danger' : 'text-success'"
               style="cursor: pointer; display: inline-block"
-              @click="showDetails(soldAppliancesList[index].id)"
+            
             >
               <md-icon>remove_red_eye</md-icon>
               {{ $tc("words.detail", 1) }}

--- a/src/frontend/src/modules/Client/Appliances/SoldAppliancesList.vue
+++ b/src/frontend/src/modules/Client/Appliances/SoldAppliancesList.vue
@@ -24,8 +24,7 @@
           v-for="(item, index) in soldAppliancesList"
           :key="index"
           :class="selectedApplianceId === item.id ? 'selected-row' : ''"
-           @click="showDetails(soldAppliancesList[index].id)"
-
+          @click="showDetails(soldAppliancesList[index].id)"
         >
           <md-table-cell md-label="Name" md-sort-by="name">
             {{ item.asset.name }}


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made
fixed Sold Appliance Details not clickable in User/Customer View

Closes: #126

<!-- Please include `closes: #XXXX to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [x] Changes tested as described above
- [x] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.
