### PR TITLE
Fix race condition in Company registration

### DIFF
--- a/src/frontend/src/modules/Register/Register.vue
+++ b/src/frontend/src/modules/Register/Register.vue
@@ -525,7 +525,6 @@ export default {
         await this.companyService.register(this.companyForm)
         this.loading = false
 
-        await this.$store.dispatch("settings/fetchPlugins")
         const email = this.companyForm.user.email
         const password = this.companyForm.user.password
 
@@ -533,6 +532,9 @@ export default {
           email,
           password,
         })
+
+        await this.$store.dispatch("settings/fetchPlugins")
+
         await this.$store.dispatch("registrationTail/getRegistrationTail")
         setTimeout(() => {
           this.$router.push("/")


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This PR resolves a race condition error at the end of company sign up. After a new user's company has been registered the frontend tries to fetch the enabled plugins. However, at this point the user isn't logged in yet, so the request fails.

Moving the call to after `auth/authenticate` fixes the issue. It remains a mystery how this ever worked.

### Are there any other side effects of this change that we should be aware of?

N/A

### Describe how you tested your changes?

```sh
docker compose up
```

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
