### PR TITLE
Fix Router Link highlighting in sidebar

### DIFF
--- a/src/frontend/src/ExportedRoutes.js
+++ b/src/frontend/src/ExportedRoutes.js
@@ -131,7 +131,7 @@ export const exportedRoutes = [
   },
   {
     path: "/",
-    component: ClusterOverviewPage,
+    redirect: "/clusters",
     name: "cluster-list-dashboard",
     meta: {
       layout: "default",
@@ -143,40 +143,7 @@ export const exportedRoutes = [
     },
   },
   {
-    path: "/clusters",
-    component: ChildRouteWrapper,
-    children: [
-      {
-        path: "",
-        component: ClusterOverviewPage,
-        name: "cluster-list",
-        meta: {
-          layout: "default",
-          breadcrumb: {
-            level: "base",
-            name: "Clusters",
-            link: "/clusters",
-          },
-        },
-      },
-      {
-        path: ":id",
-        component: ClusterDetailPage,
-        name: "cluster-detail",
-        meta: {
-          layout: "default",
-          breadcrumb: {
-            level: "detail",
-            name: "Clusters",
-            link: "/clusters",
-            target: "id",
-          },
-        },
-      },
-    ],
-  },
-  {
-    path: "/dashboards",
+    path: "",
     component: ChildRouteWrapper,
     meta: {
       sidebar: {
@@ -188,16 +155,45 @@ export const exportedRoutes = [
     children: [
       {
         path: "clusters",
-        redirect: "/",
+        component: ChildRouteWrapper,
         meta: {
           sidebar: {
             enabled: true,
             name: "Clusters",
           },
         },
+        children: [
+          {
+            path: "",
+            component: ClusterOverviewPage,
+            name: "cluster-list",
+            meta: {
+              layout: "default",
+              breadcrumb: {
+                level: "base",
+                name: "Clusters",
+                link: "/clusters",
+              },
+            },
+          },
+          {
+            path: ":id",
+            component: ClusterDetailPage,
+            name: "cluster-detail",
+            meta: {
+              layout: "default",
+              breadcrumb: {
+                level: "detail",
+                name: "Clusters",
+                link: "/clusters",
+                target: "id",
+              },
+            },
+          },
+        ],
       },
       {
-        path: "mini-grid",
+        path: "dashboards/mini-grid",
         component: ChildRouteWrapper,
         meta: {
           sidebar: {
@@ -390,7 +386,7 @@ export const exportedRoutes = [
     ],
   },
   {
-    path: "/tickets",
+    path: "",
     component: ChildRouteWrapper,
     meta: {
       sidebar: {
@@ -401,7 +397,7 @@ export const exportedRoutes = [
     },
     children: [
       {
-        path: "",
+        path: "tickets",
         component: TicketList,
         meta: {
           layout: "default",
@@ -412,14 +408,14 @@ export const exportedRoutes = [
         },
       },
       {
-        path: "settings/users",
+        path: "tickets-settings/users",
         component: TicketSettingsUsers,
         meta: {
           layout: "default",
         },
       },
       {
-        path: "settings/categories",
+        path: "tickets-settings/categories",
         component: TicketSettingsCategories,
         meta: {
           layout: "default",
@@ -470,7 +466,7 @@ export const exportedRoutes = [
     ],
   },
   {
-    path: "/meters",
+    path: "",
     component: ChildRouteWrapper,
     meta: {
       sidebar: {
@@ -481,18 +477,7 @@ export const exportedRoutes = [
     },
     children: [
       {
-        path: "types",
-        component: MeterTypeList,
-        meta: {
-          layout: "default",
-          sidebar: {
-            enabled: true,
-            name: "Types",
-          },
-        },
-      },
-      {
-        path: "",
+        path: "meters",
         component: ChildRouteWrapper,
         meta: {
           sidebar: {
@@ -527,6 +512,17 @@ export const exportedRoutes = [
             },
           },
         ],
+      },
+      {
+        path: "meters-types",
+        component: MeterTypeList,
+        meta: {
+          layout: "default",
+          sidebar: {
+            enabled: true,
+            name: "Types",
+          },
+        },
       },
     ],
   },
@@ -698,7 +694,7 @@ export const exportedRoutes = [
     },
   },
   {
-    path: "/agents",
+    path: "",
     component: ChildRouteWrapper,
     meta: {
       sidebar: {
@@ -709,8 +705,8 @@ export const exportedRoutes = [
     },
     children: [
       {
-        path: "",
-        component: AgentList,
+        path: "agents",
+        component: ChildRouteWrapper,
         meta: {
           layout: "default",
           sidebar: {
@@ -718,39 +714,41 @@ export const exportedRoutes = [
             name: "List",
           },
         },
+        children: [
+          {
+            path: "",
+            component: AgentList,
+            meta: {
+              layout: "default",
+            },
+          },
+          {
+            path: ":id",
+            component: AgentDetail,
+            meta: {
+              layout: "default",
+              breadcrumb: {
+                level: "base",
+                name: "Agents",
+                link: "/agents",
+                target: "id",
+              },
+            },
+          },
+        ],
       },
       {
-        path: "commission-types",
-        redirect: "/commissions",
+        path: "commissions",
+        component: AgentCommissionTypeList,
         meta: {
+          layout: "default",
           sidebar: {
             enabled: true,
             name: "Commission Types",
           },
         },
       },
-      {
-        path: ":id",
-        component: AgentDetail,
-        meta: {
-          layout: "default",
-          breadcrumb: {
-            level: "base",
-            name: "Agents",
-            link: "/agents",
-            target: "id",
-          },
-        },
-      },
     ],
-  },
-  {
-    // FIXME: This should probably be part of agents menu and endpoint
-    path: "/commissions",
-    component: AgentCommissionTypeList,
-    meta: {
-      layout: "default",
-    },
   },
   {
     // FIXME: Should this be part of the Customer route?

--- a/src/frontend/src/modules/Sidebar/SideBar.vue
+++ b/src/frontend/src/modules/Sidebar/SideBar.vue
@@ -28,7 +28,6 @@
             <router-link
               v-if="!hasSubMenu(menu)"
               :to="menu.path"
-              :exact-path="true"
               :key="'menu' + menu.path"
             >
               <md-list-item>
@@ -68,7 +67,6 @@
                     :key="sub.path"
                     :to="subMenuUrl(menu.path, sub.path)"
                     class="sub-menu"
-                    :exact-path="true"
                   >
                     <template
                       v-if="
@@ -247,7 +245,7 @@ export default {
   background-color: rgba(32, 66, 32, 0.74);
 }
 
-.exact-active {
+.active {
   background: #6b6a6a !important;
   position: relative;
   width: calc(100%) !important;


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Fixes the Router Link for Mini-Grid and Cluster Dashboards

<img width="680" alt="image" src="https://github.com/user-attachments/assets/8232b955-db29-46d6-a9a4-3f30a03eb3c4">

by moving to `active` class instead of `exact-active`. Requires refactoring frontend routes a bit to avoid overlap.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
