### PR TITLE
improv: ensure all commands that extend abscommand has company id option

### DIFF
--- a/src/backend/app/Console/Commands/AbstractSharedCommand.php
+++ b/src/backend/app/Console/Commands/AbstractSharedCommand.php
@@ -16,9 +16,8 @@ abstract class AbstractSharedCommand extends Command
 
     protected int $EXECUTION_TYPE = self::EXECUTE_FOR_ALL;
 
-
     /**
-     * Configure the command
+     * Configure the command.
      */
     protected function configure(): void
     {
@@ -31,7 +30,6 @@ abstract class AbstractSharedCommand extends Command
             'The ID of the company to run the command for. If not provided, runs for all companies.'
         );
     }
-
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -79,7 +77,7 @@ abstract class AbstractSharedCommand extends Command
         InputInterface $input,
         OutputInterface $output,
     ): void {
-        $this->info('Running ' . $this->name . ' for company ID : ' . $companyId);
+        $this->info('Running '.$this->name.' for company ID : '.$companyId);
         $databaseProxyManagerService->runForCompany($companyId, function () use ($input, $output) {
             parent::execute($input, $output);
         });

--- a/src/backend/app/Console/Commands/AbstractSharedCommand.php
+++ b/src/backend/app/Console/Commands/AbstractSharedCommand.php
@@ -16,6 +16,23 @@ abstract class AbstractSharedCommand extends Command
 
     protected int $EXECUTION_TYPE = self::EXECUTE_FOR_ALL;
 
+
+    /**
+     * Configure the command
+     */
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption(
+            'company-id',
+            null,
+            \Symfony\Component\Console\Input\InputOption::VALUE_OPTIONAL,
+            'The ID of the company to run the command for. If not provided, runs for all companies.'
+        );
+    }
+
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         /** @var DatabaseProxyManagerService $databaseProxyManagerService */
@@ -62,7 +79,7 @@ abstract class AbstractSharedCommand extends Command
         InputInterface $input,
         OutputInterface $output,
     ): void {
-        $this->info('Running '.$this->name.' for company ID : '.$companyId);
+        $this->info('Running ' . $this->name . ' for company ID : ' . $companyId);
         $databaseProxyManagerService->runForCompany($companyId, function () use ($input, $output) {
             parent::execute($input, $output);
         });


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

With this change, all commands that extend `AbstractSharedCommand` propagate `company-id` option. 

Closes: #91 


<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [x] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
