### PR TITLE
Add `HEALTHY` checks to local MariaDB

### DIFF
--- a/docker-compose-dockerhub.yml
+++ b/docker-compose-dockerhub.yml
@@ -77,7 +77,7 @@ services:
     ports:
       - 3306:3306
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: [CMD, healthcheck.sh, --connect, --innodb_initialized]
       start_period: 10s
       interval: 10s
       timeout: 5s

--- a/docker-compose-dockerhub.yml
+++ b/docker-compose-dockerhub.yml
@@ -5,8 +5,10 @@ services:
     image: enaccess/micropowermanager-backend:latest
     env_file: ./dev/.env.micropowermanager-backend
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -29,8 +31,10 @@ services:
       dockerfile: docker/DockerfileCron
     env_file: ./dev/.env.micropowermanager-backend
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -48,8 +52,10 @@ services:
       - ./src/backend:/var/www/laravel
       - ./docker/config/php/php.ini:/usr/local/etc/php/php.ini
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -64,12 +70,18 @@ services:
 
   maria:
     container_name: maria
-    image: mariadb:10.3
+    image: mariadb:10.11
     env_file: ./dev/.env.mysql
     volumes:
       - mariadb_data:/var/lib/mysql
     ports:
       - 3306:3306
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
 volumes:
   frontend_node_modules:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -79,7 +79,7 @@ services:
     ports:
       - 3306:3306
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: [CMD, healthcheck.sh, --connect, --innodb_initialized]
       start_period: 10s
       interval: 10s
       timeout: 5s

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -6,8 +6,10 @@ services:
       dockerfile: docker/DockerfileBackendProd
     env_file: ./dev/.env.micropowermanager-backend
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -31,8 +33,10 @@ services:
       dockerfile: docker/DockerfileCron
     env_file: ./dev/.env.micropowermanager-backend
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -50,8 +54,10 @@ services:
       - ./src/backend:/var/www/laravel
       - ./docker/config/php/php.ini:/usr/local/etc/php/php.ini
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -66,12 +72,18 @@ services:
 
   maria:
     container_name: maria
-    image: mariadb:10.3
+    image: mariadb:10.11
     env_file: ./dev/.env.mysql
     volumes:
       - mariadb_data:/var/lib/mysql
     ports:
       - 3306:3306
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
 volumes:
   frontend_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
       dockerfile: docker/DockerfileBackendDev
     env_file: ./dev/.env.micropowermanager-backend
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -34,8 +36,10 @@ services:
       dockerfile: docker/DockerfileCron
     env_file: ./dev/.env.micropowermanager-backend
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -53,8 +57,10 @@ services:
       - ./src/backend:/var/www/laravel
       - ./docker/config/php/php.ini:/usr/local/etc/php/php.ini
     depends_on:
-      - maria
-      - redis
+      maria:
+        condition: service_healthy
+      redis:
+        condition: service_started
     links:
       - maria:db
       - redis:redis
@@ -69,12 +75,18 @@ services:
 
   maria:
     container_name: maria
-    image: mariadb:10.3
+    image: mariadb:10.11
     env_file: ./dev/.env.mysql
     volumes:
       - mariadb_data:/var/lib/mysql
     ports:
       - 3306:3306
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
 volumes:
   frontend_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     ports:
       - 3306:3306
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: [CMD, healthcheck.sh, --connect, --innodb_initialized]
       start_period: 10s
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

As a follow-up to https://github.com/EnAccess/micropowermanager/pull/393 we need to make sure the MariaDB is fully up and running before we start the backend container.

Also, performing a minor version upgrade to MariaDB to use `healthcheck.sh`.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [x] Changes tested as described above
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
