### PR TITLE
use correct paid_for_type on payment #396

### DIFF
--- a/src/backend/app/Helpers/TokenGenerator.php
+++ b/src/backend/app/Helpers/TokenGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Helpers;
+
+class TokenGenerator {
+    /**
+     * Generate a random 12-digit token.
+     *
+     * @return string
+     */
+    public static function generate() {
+        $token = '';
+        for ($i = 0; $i < 12; ++$i) {
+            $token .= random_int(0, 9);
+        }
+
+        return $token;
+    }
+}

--- a/src/frontend/src/mixins/token.js
+++ b/src/frontend/src/mixins/token.js
@@ -1,0 +1,11 @@
+export const token = {
+  methods: {
+    formatToken(token) {
+      // Ensure token is a string
+      const tokenStr = String(token)
+      // Format in the desired pattern
+      // return tokenStr.match(/.{1,4}/g).join('-'); // For "1234-1234-1234"
+      return tokenStr.match(/.{1,3}/g).join(" ") // For "123 412 341 234"
+    },
+  },
+}

--- a/src/frontend/src/modules/Meter/Transactions.vue
+++ b/src/frontend/src/modules/Meter/Transactions.vue
@@ -94,10 +94,10 @@ export default {
     },
     formatToken(token) {
       // Ensure token is a string
-      const tokenStr = String(token);
+      const tokenStr = String(token)
       // Format in the desired pattern
       // return tokenStr.match(/.{1,4}/g).join('-'); // For "1234-1234-1234"
-      return tokenStr.match(/.{1,3}/g).join(' '); // For "123 412 341 234"
+      return tokenStr.match(/.{1,3}/g).join(" ") // For "123 412 341 234"
     },
   },
 }

--- a/src/frontend/src/modules/Meter/Transactions.vue
+++ b/src/frontend/src/modules/Meter/Transactions.vue
@@ -30,8 +30,8 @@
               {{ token.paid_for_type }}
             </md-table-cell>
             <md-table-cell
-              v-if="token.paid_for_type === 'token'"
-              v-text="readable(token.paid_for.energy) + 'kWh'"
+              v-if="token.paid_for_type === 'App\\Models\\Token'"
+              v-text="readable(token.paid_for.energy) + ' kWh'"
             ></md-table-cell>
             <md-table-cell v-else>-</md-table-cell>
             <md-table-cell
@@ -49,10 +49,11 @@ import Widget from "../../shared/widget"
 import { EventBus } from "@/shared/eventbus"
 import { currency } from "@/mixins/currency"
 import { timing } from "@/mixins/timing"
+import { token } from "@/mixins/token"
 
 export default {
   name: "Transactions.vue",
-  mixins: [currency, timing],
+  mixins: [currency, timing, token],
   components: { Widget },
   props: {
     transactions: {
@@ -91,13 +92,6 @@ export default {
         this.subscriber,
         this.transactions.tokens.length,
       )
-    },
-    formatToken(token) {
-      // Ensure token is a string
-      const tokenStr = String(token)
-      // Format in the desired pattern
-      // return tokenStr.match(/.{1,4}/g).join('-'); // For "1234-1234-1234"
-      return tokenStr.match(/.{1,3}/g).join(" ") // For "123 412 341 234"
     },
   },
 }

--- a/src/frontend/src/modules/Meter/Transactions.vue
+++ b/src/frontend/src/modules/Meter/Transactions.vue
@@ -23,8 +23,8 @@
             <md-table-cell
               v-text="moneyFormat(token.transaction.amount)"
             ></md-table-cell>
-            <md-table-cell v-if="token.paid_for_type === 'token'">
-              Token {{ token.paid_for.token }}
+            <md-table-cell v-if="token.paid_for_type === 'App\\Models\\Token'">
+              Token ({{ formatToken(token.paid_for.token) }})
             </md-table-cell>
             <md-table-cell v-else>
               {{ token.paid_for_type }}
@@ -91,6 +91,13 @@ export default {
         this.subscriber,
         this.transactions.tokens.length,
       )
+    },
+    formatToken(token) {
+      // Ensure token is a string
+      const tokenStr = String(token);
+      // Format in the desired pattern
+      // return tokenStr.match(/.{1,4}/g).join('-'); // For "1234-1234-1234"
+      return tokenStr.match(/.{1,3}/g).join(' '); // For "123 412 341 234"
     },
   },
 }


### PR DESCRIPTION
- seed meter tokens table for demo company
- use appropriate paid_for_type as expected on the frontend

<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made


This PR seeds the meter_tokens table, which ensures the `tokens` field is correctly returned with values on the `api/meters/{meter_id}/` endpoint.

Also on success payment, the payment history `paid_for_type` is updated to match expected values on the frontend. 

Closes: #396
Closes: #83

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

We can now see the tokens on the transaction 

<img width="1454" alt="Screenshot 2024-12-08 at 8 55 17 PM" src="https://github.com/user-attachments/assets/554edded-8e80-47e9-bbf8-15240e5551c1">


### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
