### PR TITLE
Fix strict mode in Seeder

### DIFF
--- a/src/backend/packages/inensus/ticket/src/Services/TicketUserService.php
+++ b/src/backend/packages/inensus/ticket/src/Services/TicketUserService.php
@@ -62,9 +62,10 @@ class TicketUserService implements IBaseService {
                 ->firstOrFail();
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException) {
             $result = $this->ticketUser->newQuery()->create([
-                'user_id' => $user->getId(),
-                'phone' => null,
                 'user_name' => $user->getName(),
+                'phone' => null,
+                'out_source' => 0,
+                'user_id' => $user->getId(),
             ]);
         }
 


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

In https://github.com/EnAccess/micropowermanager/pull/385 we have switched the Tenant database connection to `strict` mode. 

Fixes

```
Illuminate\Database\QueryException {"message":"SQLSTATE[HY000]: General error: 1364 Field 'out_source' doesn't have a default value (SQL: insert into `ticket_users` (`user_id`, `phone`, `user_name`, `updated_at`, `created_at`) values (1, ?, Demo Company Admin, 2024-12-12 08:57:01, 2024-12-12 08:57:01))"
```

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
