### PR TITLE
Make SQL statement MySQL complicated

### DIFF
--- a/src/backend/app/Models/PaymentHistory.php
+++ b/src/backend/app/Models/PaymentHistory.php
@@ -42,7 +42,7 @@ class PaymentHistory extends BaseModel {
             FROM payment_histories
             WHERE payer_id = :payer_id AND payer_type = :payer_type
             GROUP BY aperiod, payment_type
-            ORDER BY created_at {$order};
+            ORDER BY aperiod {$order};
             SQL;
 
         if ($limit !== null) {


### PR DESCRIPTION
### Brief summary of the change made

Fixes

```
SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'DemoCompany_1.payment_histories.created_at' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

when running with MySQL rather than MariaDB.

Makes progress on: #500 

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
