### PR TITLE
Fix Slack logging being enabled always

### DIFF
--- a/docs/installation/configuration-production.md
+++ b/docs/installation/configuration-production.md
@@ -61,6 +61,23 @@ $mailHelper = app(App\Helpers\MailHelper::class);
 $mailHelper->sendPlain('test@example.org', '[TEST] Welcome to MicroPowerManager', 'lorem ipsum');
 ```
 
+## Logging
+
+> [!INFO]
+> This section is optional, but recommended.
+
+Set up a logging channel which allows you to monitor critical errors of the application in realtime.
+
+Currently, we support Slack logging using [incoming webhooks](https://api.slack.com/messaging/webhooks).
+Set the following environment variables
+
+- `LOG_SLACK_WEBHOOK_URL`
+
+By default, we are logging `CRITICAL` errors.
+To increase the logging level (for example to investigate errors), set
+
+- `LOG_LEVEL`
+
 ## Agent Apps
 
 Placeholder, do this, do that

--- a/docs/installation/environment-variables.md
+++ b/docs/installation/environment-variables.md
@@ -118,12 +118,13 @@ We recommend running MicroPowerManager with [Pusher Channels](https://pusher.com
 
 Set of environment variables that can be used to configure logging and logging providers in MicroPowerManager.
 
-| Environment Variable    | Default                          | Description                                                                                                                                                                 |
-| ----------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LOG_CHANNEL`           | `stack`                          | Log channel. For more information about available log channels, see [`logging.php`](https://github.com/EnAccess/micropowermanager/blob/main/src/backend/config/logging.php) |
-| `LOGGLY_TOKEN`          | **Required** (When using Loggly) | Access token for [Loggly](https://www.loggly.com/).                                                                                                                         |
-| `LOG_LEVEL`             | `debug`                          | Level of the logs send to [Loggly](https://www.loggly.com/).                                                                                                                |
-| `LOG_SLACK_WEBHOOK_URL` | **Required** (When using Slack)  | Slack Webhook URL                                                                                                                                                           |
+| Environment Variable    | Default                                 | Description                                                                                                                                                                 |
+| ----------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOG_CHANNEL`           | `stack`                                 | Log channel. For more information about available log channels, see [`logging.php`](https://github.com/EnAccess/micropowermanager/blob/main/src/backend/config/logging.php) |
+| `LOG_LEVEL`             | `debug`                                 | Level of the logs.                                                                                                                                                          |
+| `LOG_SLACK_WEBHOOK_URL` | **Required** (When using Slack Logging) | Slack Webhook URL. This require a [Slack incoming webhook](https://api.slack.com/messaging/webhooks). If `LOG_SLACK_WEBHOOK_URL` is provided Slack logging will be enabled. |
+| `LOG_SLACK_USERNAME`    | `Laravel Log`                           | Slack Webhook URL                                                                                                                                                           |
+| `LOG_SLACK_EMOJI`       | `:boom:`                                | Slack Webhook URL                                                                                                                                                           |
 
 #### Email
 

--- a/src/backend/config/logging.php
+++ b/src/backend/config/logging.php
@@ -1,23 +1,6 @@
 <?php
 
-use Monolog\Handler\LogglyHandler;
 use Monolog\Handler\StreamHandler;
-
-$slack = [
-    'driver' => 'slack',
-    'url' => env('LOG_SLACK_WEBHOOK_URL'),
-    'username' => 'Error Messenger',
-    'emoji' => ':boom:',
-    'level' => 'critical',
-];
-
-if (in_array(config('app.env'), ['development', 'local'])) {
-    $slack = [
-        'level' => 'critical',
-        'driver' => 'errorlog',
-        'path' => storage_path('logs/critical.log'),
-    ];
-}
 
 return [
     /*
@@ -51,7 +34,13 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single', 'slack'],
+            // `single` is our default log channel.
+            // Third party logging tools will be enabled passed on the corresponding
+            // environment variables.
+            'channels' => array_filter([
+                'single',
+                env('LOG_SLACK_WEBHOOK_URL') ? 'slack' : null,
+            ]),
         ],
 
         'single' => [
@@ -66,7 +55,15 @@ return [
             'level' => 'debug',
             'days' => 7,
         ],
-        'slack' => $slack,
+
+        'slack' => [
+            'driver' => 'slack',
+            'url' => env('LOG_SLACK_WEBHOOK_URL'),
+            'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+            'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
+            'level' => env('LOG_LEVEL', 'critical'),
+        ],
+
         'stderr' => [
             'driver' => 'monolog',
             'handler' => StreamHandler::class,

--- a/src/backend/config/logging.php
+++ b/src/backend/config/logging.php
@@ -10,23 +10,9 @@ $slack = [
     'emoji' => ':boom:',
     'level' => 'critical',
 ];
-$loggly = [
-    'driver' => 'monolog',
-    'level' => env('LOG_LEVEL', 'debug'),
-    'handler' => LogglyHandler::class,
-    'with' => [
-        'token' => env('LOGGLY_TOKEN'),
-    ],
-];
 
 if (in_array(config('app.env'), ['development', 'local'])) {
     $slack = [
-        'level' => 'critical',
-        'driver' => 'errorlog',
-        'path' => storage_path('logs/critical.log'),
-    ];
-
-    $loggly = [
         'level' => 'critical',
         'driver' => 'errorlog',
         'path' => storage_path('logs/critical.log'),
@@ -65,7 +51,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single', 'slack', 'loggly'],
+            'channels' => ['single', 'slack'],
         ],
 
         'single' => [
@@ -80,7 +66,6 @@ return [
             'level' => 'debug',
             'days' => 7,
         ],
-        'loggly' => $loggly,
         'slack' => $slack,
         'stderr' => [
             'driver' => 'monolog',


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Currently, the Slack logger is always enabled on non-development environments, which throws errors. Closes: #533 

Only enable Slack logging when the corresponding environment variable is set and update documentation accordingly.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
