### PR TITLE
Fix Mail debugging failing API response

### DIFF
--- a/docs/installation/configuration-production.md
+++ b/docs/installation/configuration-production.md
@@ -59,6 +59,7 @@ Then
 ```php
 $mailHelper = app(App\Helpers\MailHelper::class);
 $mailHelper->sendPlain('test@example.org', '[TEST] Welcome to MicroPowerManager', 'lorem ipsum');
+$mailHelper->sendViaTemplate('test@example.org', '[TEST] Welcome to MicroPowerManager', 'templates.mail.register_welcome', ['userName' => 'Lorem', 'companyName' => 'Ipsum']);
 ```
 
 ## Logging

--- a/src/backend/app/Helpers/MailHelper.php
+++ b/src/backend/app/Helpers/MailHelper.php
@@ -30,7 +30,13 @@ class MailHelper implements MailHelperInterface {
         $this->mailer->Password = $this->mailSettings['password'];
         $this->mailer->From = $this->mailSettings['default_sender'];
         $this->mailer->SMTPDebug = $this->mailSettings['debug_level'];
+        $this->mailer->Debugoutput = 'error_log';
         $this->mailer->isSMTP();
+        // When debugging Email sending locally it might helpful to explicitly set a Hostname
+        // as certain mail providers might block traffic with Hostname `localhost`.
+        // And `$_SERVER['SERVER_NAME']` is `localhost` in our local development setup.
+        // https://phpmailer.github.io/PHPMailer/classes/PHPMailer-PHPMailer-PHPMailer.html#property_Hostname
+        // $this->mailer->Hostname = gethostname();
     }
 
     /**

--- a/src/backend/config/mail.php
+++ b/src/backend/config/mail.php
@@ -43,7 +43,7 @@ return [
             'password' => env('MAIL_SMTP_PASSWORD'),
             'default_sender' => env('MAIL_SMTP_DEFAULT_SENDER'),
             'default_message' => env('MAIL_SMTP_DEFAULT_MESSAGE', 'Please do not reply to this email'),
-            'debug_level' => env('MAIL_SMTP_DEBUG_LEVEL', 'Please do not reply to this email'),
+            'debug_level' => env('MAIL_SMTP_DEBUG_LEVEL', 0),
             'timeout' => null,
             'auth_mode' => null,
         ],


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Make sure our PHPMailer debugging goes to `error_log` rather than `echo` where it will end up in the HTTP response and cause errors in the frontend.

Additionally, adding some useful instructions for debugging locally.

Closes: #534 

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
