### PR TITLE
Fix `SQL` error in `queryOutstandingDebtsByApplianceRates`

### DIFF
--- a/src/backend/app/Services/ApplianceRateService.php
+++ b/src/backend/app/Services/ApplianceRateService.php
@@ -153,7 +153,6 @@ class ApplianceRateService {
             ->with(['assetPerson.asset', 'assetPerson.person'])
             ->where('due_date', '<', $toDate->format('Y-m-d'))
             ->where('remaining', '>', 0)
-            ->groupBy('asset_person_id')
             ->orderBy('id');
     }
 }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Closes: #563 

```sh
SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'DemoCompany_1.asset_rates.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by (SQL: select * from asset_rates where due_date < 2025-03-16 and remaining > 0 group by asset_person_id order by id asc)
```

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
