### PR TITLE
Remove call `userService` in constructor

### DIFF
--- a/src/backend/app/Services/SmsAndroidSettingService.php
+++ b/src/backend/app/Services/SmsAndroidSettingService.php
@@ -8,16 +8,19 @@ class SmsAndroidSettingService {
     private string $fireBaseKey;
     private string $callbackUrl;
 
-    public function __construct(private SmsAndroidSetting $smsAndroidSetting, private UserService $userService) {
-        $this->fireBaseKey = config('services.sms.android.key');
-        $this->callbackUrl = config('services.sms.callback').$this->userService->getCompanyId();
-    }
+    public function __construct(
+        private SmsAndroidSetting $smsAndroidSetting,
+        private UserService $userService,
+    ) {}
 
     public function getSmsAndroidSetting() {
         return $this->smsAndroidSetting->newQuery()->get();
     }
 
     public function createSmsAndroidSetting($androidPhoneToken) {
+        $this->fireBaseKey = config('services.sms.android.key');
+        $this->callbackUrl = config('services.sms.callback').$this->userService->getCompanyId();
+
         $smsAndroidSettingData = [
             'callback' => $this->callbackUrl,
             'token' => $androidPhoneToken,
@@ -29,8 +32,8 @@ class SmsAndroidSettingService {
     }
 
     public function updateSmsAndroidSetting(SmsAndroidSetting $smsAndroidSetting, $androidPhoneToken) {
-        $fireBaseKey = config('services.sms.android.key');
-        $callbackUrl = config('services.sms.android.callback_url').$this->userService->getCompanyId();
+        $this->fireBaseKey = config('services.sms.android.key');
+        $this->callbackUrl = config('services.sms.android.callback_url').$this->userService->getCompanyId();
 
         $smsAndroidSetting->update([
             'callback' => $this->callbackUrl,

--- a/src/backend/app/Services/UserService.php
+++ b/src/backend/app/Services/UserService.php
@@ -12,7 +12,10 @@ use Illuminate\Support\Collection;
 use MPM\User\Events\UserCreatedEvent;
 
 class UserService {
-    public function __construct(private User $user, private MailHelperInterface $mailHelper) {}
+    public function __construct(
+        private User $user,
+        private MailHelperInterface $mailHelper,
+    ) {}
 
     public function create(array $userData, ?int $companyId = null): User {
         $shouldSyncUserWithMasterDatabase = $companyId !== null;


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

`UserService` is a tenant model. It's method should not be called on constructor level as the Tenant database connection might not be established at that time.

This fixes CLI issues with `php artisan route:list` and `php artisan test`.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
