### PR TITLE
feat: support filter by agent id on `api/people` endpoint

### DIFF
--- a/collections/Get Customers.bru
+++ b/collections/Get Customers.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Customers
+  type: http
+  seq: 19
+}
+
+get {
+  url: {{mpm_backend_url}}/api/people?per_page=15
+  body: none
+  auth: inherit
+}
+
+params:query {
+  per_page: 15
+  ~agent_id: 1
+}

--- a/src/backend/app/Http/Controllers/PersonController.php
+++ b/src/backend/app/Http/Controllers/PersonController.php
@@ -41,8 +41,9 @@ class PersonController extends Controller {
     public function index(Request $request): ApiResource {
         $customerType = $request->input('is_customer', 1);
         $limit = $request->input('limit', config('settings.paginate'));
+        $agentId = $request->input('agent_id');
 
-        return ApiResource::make($this->personService->getAll($limit, $customerType));
+        return ApiResource::make($this->personService->getAll($limit, $customerType, $agentId));
     }
 
     /**

--- a/src/backend/app/Services/PersonService.php
+++ b/src/backend/app/Services/PersonService.php
@@ -149,14 +149,23 @@ class PersonService implements IBaseService {
         return $person->delete();
     }
 
-    public function getAll(?int $limit = null, $customerType = 1): LengthAwarePaginator {
-        return $this->person->newQuery()->with([
+    public function getAll(?int $limit = null, $customerType = 1, $agentId = null): LengthAwarePaginator {
+        $query = $this->person->newQuery()->with([
             'addresses' => function ($q) {
                 return $q->where('is_primary', 1);
             },
             'addresses.city',
             'devices',
-        ])->where('is_customer', $customerType)->paginate($limit);
+            'agentSoldAppliance.assignedAppliance.agent',
+        ])->where('is_customer', $customerType);
+
+        if ($agentId) {
+            $query->whereHas('agentSoldAppliance.assignedAppliance.agent', function ($q) use ($agentId) {
+                $q->where('id', $agentId);
+            });
+        }
+
+        return $query->paginate($limit);
     }
 
     public function createFromRequest(Request $request): Person {


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This PR adds support for any optional query parameter `agent_id` on the get customers endpoint (`api/people`). 

Also it includes an agent sold appliance relation field `agent_sold_appliance` to the customer object. 


closes: #550


<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
