### PR TITLE
Fix No-Dev install `composer install` in prod containers

### DIFF
--- a/src/backend/composer.json
+++ b/src/backend/composer.json
@@ -60,11 +60,7 @@
       "App\\": "app/",
       "Database\\Factories\\": "database/factories/",
       "Database\\Seeders\\": "database/seeders/",
-      "MPM\\": "app/modules"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
+      "MPM\\": "app/modules",
       "Inensus\\Ticket\\": "packages/inensus/ticket/src",
       "Inensus\\SparkMeter\\": "packages/inensus/spark-meter/src",
       "Inensus\\SteamaMeter\\": "packages/inensus/steama-meter/src",
@@ -83,7 +79,11 @@
       "Inensus\\WavecomPaymentProvider\\": "packages/inensus/wavecom-payment-provider/src",
       "Inensus\\DalyBms\\": "packages/inensus/daly-bms/src",
       "Inensus\\AngazaSHS\\": "packages/inensus/angaza-shs/src",
-      "Inensus\\AfricasTalking\\": "packages/inensus/africas-talking/src",
+      "Inensus\\AfricasTalking\\": "packages/inensus/africas-talking/src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "Tests\\": "tests/"
     }
   },


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Fixes:

```
6.989 In ProviderRepository.php line 206:
6.990                                                                             
6.990   Class "Inensus\SparkMeter\Providers\SparkMeterServiceProvider" not found  
6.990                                                                             
6.990 
6.996 Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
