### PR TITLE
Fix: Restore Sidebar Click Functionality Removed in PR #632

### DIFF
--- a/src/frontend/src/modules/Sidebar/SideBar.vue
+++ b/src/frontend/src/modules/Sidebar/SideBar.vue
@@ -207,6 +207,31 @@ export default {
   flex-direction: column;
   height: 100%;
 }
+.sidebar-wrapper {
+    position: relative;
+    z-index: 4;
+    .dropdown .dropdown-backdrop {
+      display: none !important;
+    }
+
+    .navbar-form {
+      border: none;
+    }
+
+    .nav {
+      padding: 0;
+
+      [data-toggle="collapse"] ~ div > ul > li > a {
+        padding-left: 60px;
+      }
+
+      .caret {
+        margin-top: 13px;
+        position: absolute;
+        right: 18px;
+      }
+    }
+  }
 
 .logo.fixed-logo {
   position: sticky;

--- a/src/frontend/src/modules/Sidebar/SideBar.vue
+++ b/src/frontend/src/modules/Sidebar/SideBar.vue
@@ -208,30 +208,30 @@ export default {
   height: 100%;
 }
 .sidebar-wrapper {
-    position: relative;
-    z-index: 4;
-    .dropdown .dropdown-backdrop {
-      display: none !important;
+  position: relative;
+  z-index: 4;
+  .dropdown .dropdown-backdrop {
+    display: none !important;
+  }
+
+  .navbar-form {
+    border: none;
+  }
+
+  .nav {
+    padding: 0;
+
+    [data-toggle="collapse"] ~ div > ul > li > a {
+      padding-left: 60px;
     }
 
-    .navbar-form {
-      border: none;
-    }
-
-    .nav {
-      padding: 0;
-
-      [data-toggle="collapse"] ~ div > ul > li > a {
-        padding-left: 60px;
-      }
-
-      .caret {
-        margin-top: 13px;
-        position: absolute;
-        right: 18px;
-      }
+    .caret {
+      margin-top: 13px;
+      position: absolute;
+      right: 18px;
     }
   }
+}
 
 .logo.fixed-logo {
   position: sticky;


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This PR fixes a regression introduced in [PR #632](https://github.com/EnAccess/micropowermanager/compare/fix-none-clickable-sidebar?expand=1#632), where the sidebar became unclickable. The issue was caused by the accidental removal of an essential CSS class responsible for enabling interactions with the sidebar.


<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?
Apologies for the oversight in the previous PR. This fix restores the expected behavior without introducing any other changes.
### Describe how you tested your changes?
- Re-added the missing CSS class that was unintentionally removed.
- Verified that the sidebar is now fully functional and clickable again.
<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
