### PR TITLE
Change internal loadbalancer IP to `SHARED_LOADBALANCER_VIP`

### DIFF
--- a/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
@@ -12,9 +12,11 @@ components:
 
 images:
   - name: enaccess/micropowermanager-backend:latest
-    newTag: 0.0.19
+    newTag: 0.0.25
   - name: enaccess/micropowermanager-frontend:latest
-    newTag: 0.0.19
+    newTag: 0.0.25
+  - name: enaccess/micropowermanager-scheduler:latest
+    newTag: 0.0.25
 
 patches:
   - path: configmap-cloud-backend.yaml
@@ -25,7 +27,7 @@ patches:
     target:
       kind: ConfigMap
       name: mpm-configmap-frontend
-  # Setting a static IP external address for our load balancer, see
+  # Setting a static IP external address for our external loadbalancer, see
   # https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip#use_an_ingress
   - patch: |-
       apiVersion: networking.k8s.io/v1
@@ -34,14 +36,16 @@ patches:
         name: mpm-ingress
         annotations:
           kubernetes.io/ingress.global-static-ip-name: loadbalancer-global-address-cloud
-  # Setting a static internal IP address for our load balancer, see
+  # Setting a static internal IP address and TLS for our internal loadbalancer, see
   # https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#static_ip_addressing
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#https_between_client_and_load_balancer
   - patch: |-
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
         name: mpm-ingress-internal
         annotations:
+          ingress.gcp.kubernetes.io/pre-shared-cert: internal-loadbalancer-cert-cloud
           kubernetes.io/ingress.regional-static-ip-name: internal-loadbalancer-address-cloud
   - patch: |-
       apiVersion: networking.gke.io/v1

--- a/terraform/gcp_kubernetes/main.tf
+++ b/terraform/gcp_kubernetes/main.tf
@@ -143,6 +143,8 @@ resource "google_compute_address" "internal_loadbalancer_address" {
   name         = local.network_internal_loadbalancer_address_name
   region       = var.gcp_region
   address_type = "INTERNAL"
+  address      = var.internal_loadbalancer_address
+  purpose      = "SHARED_LOADBALANCER_VIP"
   subnetwork   = "default"
 }
 

--- a/terraform/gcp_kubernetes/variables.tf
+++ b/terraform/gcp_kubernetes/variables.tf
@@ -53,7 +53,7 @@ EOT
   default     = null
 
   validation {
-    condition     = (
+    condition = (
       var.internal_loadbalancer_address == null ||
       can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}$", var.internal_loadbalancer_address))
     )

--- a/terraform/gcp_kubernetes/variables.tf
+++ b/terraform/gcp_kubernetes/variables.tf
@@ -38,6 +38,29 @@ variable "create_internal_loadbalancer_address" {
   default     = false
 }
 
+variable "internal_loadbalancer_address" {
+  description = <<EOT
+Optional static internal IP address for the load balancer.
+
+If provided, the load balancer will use this specific IP instead of automatically assigning one.
+This IP must be part of the subnet associated with the region.
+
+In most cases, this can be left blank. However, specifying a static IP is useful when the same
+address needs to be reused — for example, during reprovisioning — to ensure continuity for external systems
+that depend on a consistent internal IP.
+EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = (
+      var.internal_loadbalancer_address == null ||
+      can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}$", var.internal_loadbalancer_address))
+    )
+    error_message = "If set, internal_loadbalancer_address must be a valid IPv4 address."
+  }
+}
+
 variable "db_tier" {
   description = "The machine type to use for the Cloud SQL database. See tiers for more details and supported versions."
   type        = string


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Change internal loadbalancer IP to `SHARED_LOADBALANCER_VIP`. This allows us to internally expose HTTP and HTTPS (with self signed certificate). See: https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#https_between_client_and_load_balancer

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
