### PR TITLE
Donot redeploy IPSec gatway on image changes

### DIFF
--- a/terraform/gcp_external_ipsec_gateway/main.tf
+++ b/terraform/gcp_external_ipsec_gateway/main.tf
@@ -47,6 +47,12 @@ resource "google_compute_instance" "ipsec_gateway" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      boot_disk[0].initialize_params[0].image
+    ]
+  }
+
   network_interface {
     network = "default"
     access_config {


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Prevent the IPSec Gateway from being re-deployed when the Ubuntu boot images changes in the repo (which is expected to happen frequently).

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
