### PR TITLE
Allow Agent logins without `device-id` header

### DIFF
--- a/src/backend/app/Http/Controllers/AgentAuthController.php
+++ b/src/backend/app/Http/Controllers/AgentAuthController.php
@@ -52,7 +52,7 @@ class AgentAuthController extends Controller {
         // if the Agent app sends us a agent-device-id in the header
         // we update the agent in db
         $deviceId = $request->header('device-id');
-        if (!$deviceId) {
+        if ($deviceId) {
             $agentId = $this->guard()->user()->id;
             $agent = $this->agentService->getById($agentId);
             $this->agentService->updateDevice($agent, $deviceId);

--- a/src/backend/app/Http/Controllers/AgentAuthController.php
+++ b/src/backend/app/Http/Controllers/AgentAuthController.php
@@ -49,14 +49,14 @@ class AgentAuthController extends Controller {
             return response()->json(['data' => ['message' => 'Unauthorized', 'status' => 401]], 401);
         }
 
+        // if the Agent app sends us a agent-device-id in the header
+        // we update the agent in db
         $deviceId = $request->header('device-id');
         if (!$deviceId) {
-            return response()->json(['data' => ['message' => 'Missing device-id header', 'status' => 400]], 400);
+            $agentId = $this->guard()->user()->id;
+            $agent = $this->agentService->getById($agentId);
+            $this->agentService->updateDevice($agent, $deviceId);
         }
-
-        $agentId = $this->guard()->user()->id;
-        $agent = $this->agentService->getById($agentId);
-        $this->agentService->updateDevice($agent, $deviceId);
 
         return $this->respondWithToken($token);
     }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

A follow up to https://github.com/EnAccess/micropowermanager/pull/620

Instead of throwing an error changing the logic to allow logins without `device-id` header. And only execute the agent update when the `device-id` is present.

The motivation behind this is, that apparently the first login in app doesn't send `device-id`:

![share_5155834754966913976](https://github.com/user-attachments/assets/f76f894a-55be-4f3a-8839-18ca66abbcd7)


### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
