### PR TITLE
Fix month overflow in periods when called on end of month

### DIFF
--- a/collections/Get Cluster Dashboard.bru
+++ b/collections/Get Cluster Dashboard.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Cluster Dashboard
+  type: http
+  seq: 23
+}
+
+get {
+  url: {{mpm_backend_url}}/api/dashboard/clusters
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 200
+  res.body.data: isJson
+}

--- a/src/backend/app/Services/PeriodService.php
+++ b/src/backend/app/Services/PeriodService.php
@@ -33,6 +33,10 @@ class PeriodService {
         if ($interval === 'weekly') {
             $i = new \DateInterval('P1W');
         } else {
+            // Make sure we don't overflow (and hence skip) a month if this is called with end date 31st.
+            // See: https://www.php.net/manual/en/datetime.examples-arithmetic.php
+            $begin = (new \DateTime($startDate))->modify('first day of this month');
+            $end = (new \DateTime($endDate))->modify('last day of this month')->setTime(0, 0, 1);
             $i = new \DateInterval('P1M');
         }
         $period = new \DatePeriod($begin, $i, $end);


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Closes: #691 

This fixes date overflows in PHP, see https://www.php.net/manual/en/datetime.examples-arithmetic.php

For example 

```php
$begin = new \DateTime('2023-01-31');
$end = new \DateTime('2023-06-01');
$interval = new \DateInterval('P1M');
$period = new \DatePeriod($begin, $interval, $end);

foreach ($period as $date) {
    echo $date->format('Y-m-d') . PHP_EOL;
}
```

yields

```sh
2023-01-31
2023-03-03
2023-04-03
2023-05-03
```

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
