### PR TITLE
Convert float columns to use double

### DIFF
--- a/src/backend/database/migrations/tenant/2019_11_06_121116_create_energies_table.php
+++ b/src/backend/database/migrations/tenant/2019_11_06_121116_create_energies_table.php
@@ -19,10 +19,10 @@ return new class extends Migration {
             $table->integer('node_id');
             $table->string('device_id');
             $table->double('total_energy');
-            $table->float('used_energy_since_last');
+            $table->double('used_energy_since_last');
             $table->string('total_absorbed_unit');
-            $table->float('total_absorbed');
-            $table->float('absorbed_energy_since_last');
+            $table->double('total_absorbed');
+            $table->double('absorbed_energy_since_last');
             $table->string('absorbed_energy_since_last_unit');
             $table->timestamp('read_out');
             $table->timestamps();

--- a/src/backend/database/migrations/tenant/2020_12_17_144527_create_main_settings_table.php
+++ b/src/backend/database/migrations/tenant/2020_12_17_144527_create_main_settings_table.php
@@ -20,8 +20,8 @@ return new class extends Migration {
             $table->char('currency', 10);
             $table->char('country', 100);
             $table->char('language', 10);
-            $table->float('vat_energy', 5);
-            $table->float('vat_appliance', 5);
+            $table->double('vat_energy');
+            $table->double('vat_appliance');
             $table->timestamps();
         });
 

--- a/src/backend/database/migrations/tenant/2024_10_23_153042_add_amount_to_agent_charge.php
+++ b/src/backend/database/migrations/tenant/2024_10_23_153042_add_amount_to_agent_charge.php
@@ -12,7 +12,7 @@ return new class extends Migration {
      */
     public function up() {
         Schema::connection('tenant')->table('agent_charges', function (Blueprint $table) {
-            $table->float('amount')->after('user_id');
+            $table->double('amount')->after('user_id');
         });
     }
 

--- a/src/backend/database/migrations/tenant/2024_10_31_180510_remove_energies_table.php
+++ b/src/backend/database/migrations/tenant/2024_10_31_180510_remove_energies_table.php
@@ -28,25 +28,25 @@ return new class extends Migration {
             $table->integer('node_id');
             $table->string('device_id');
             $table->double('total_energy');
-            $table->float('used_energy_since_last');
+            $table->double('used_energy_since_last');
             $table->string('total_absorbed_unit');
-            $table->float('total_absorbed');
-            $table->float('absorbed_energy_since_last');
+            $table->double('total_absorbed');
+            $table->double('absorbed_energy_since_last');
             $table->string('absorbed_energy_since_last_unit');
             $table->timestamp('read_out');
             $table->timestamps();
         });
 
         Schema::connection('tenant')->table('energies', function (Blueprint $table) {
-            $table->double('used_energy_since_last', 15, 2)->default(0)->change();
-            $table->double('total_absorbed', 15, 2)->default(0)->change();
-            $table->double('absorbed_energy_since_last', 15, 2)->default(0)->change();
+            $table->double('used_energy_since_last')->default(0)->change();
+            $table->double('total_absorbed')->default(0)->change();
+            $table->double('absorbed_energy_since_last')->default(0)->change();
         });
 
         Schema::connection('tenant')->table('energies', function (Blueprint $table) {
-            $table->double('used_energy_since_last', 8, 4)->default(0)->change();
-            $table->double('total_absorbed', 8, 4)->default(0)->change();
-            $table->double('absorbed_energy_since_last', 8, 4)->default(0)->change();
+            $table->double('used_energy_since_last')->default(0)->change();
+            $table->double('total_absorbed')->default(0)->change();
+            $table->double('absorbed_energy_since_last')->default(0)->change();
         });
     }
 };


### PR DESCRIPTION
The PR updates the `float` columns to use `double` as needed for Laravel 11 upgrade.

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
