### PR TITLE
Remove precision arguments from double columns in migrations

### DIFF
--- a/src/backend/database/migrations/tenant/2020_12_23_165814_create_map_settings_table.php
+++ b/src/backend/database/migrations/tenant/2020_12_23_165814_create_map_settings_table.php
@@ -16,8 +16,8 @@ return new class extends Migration {
         Schema::connection('tenant')->create('map_settings', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('zoom');
-            $table->double('latitude', 10);
-            $table->double('longitude', 10);
+            $table->double('latitude');
+            $table->double('longitude');
             $table->string('bingMapApiKey')->nullable();
             $table->string('provider')->nullable();
             $table->timestamps();

--- a/src/backend/database/migrations/tenant/2021_06_04_085817_update_meter_consumptions_table.php
+++ b/src/backend/database/migrations/tenant/2021_06_04_085817_update_meter_consumptions_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('meter_consumptions', function (Blueprint $table) {
-            $table->renameColumn('daily_consumption', 'consumption')->double('consumption', 15, 4)->default(0)->change();
+            $table->renameColumn('daily_consumption', 'consumption')->double('consumption')->default(0)->change();
             $table->datetime('reading_date')->change();
         });
     }

--- a/src/backend/database/migrations/tenant/2022_05_10_093215_update_meter_tariffs_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_093215_update_meter_tariffs_table.php
@@ -17,8 +17,8 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('meter_tariffs', function (Blueprint $table) {
-            $table->double('price', 15, 6)->change();
-            $table->double('total_price', 15, 6)->change();
+            $table->double('price')->change();
+            $table->double('total_price')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_101348_update_social_tariffs_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_101348_update_social_tariffs_table.php
@@ -17,8 +17,8 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('social_tariffs', function (Blueprint $table) {
-            $table->double('price', 15, 6)->change();
-            $table->double('initial_energy_budget', 15, 6)->change();
+            $table->double('price')->change();
+            $table->double('initial_energy_budget')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_101616_update_tariff_pricing_components_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_101616_update_tariff_pricing_components_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('tariff_pricing_components', function (Blueprint $table) {
-            $table->double('price', 15, 6)->change();
+            $table->double('price')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_101855_update_social_tariff_piggy_banks_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_101855_update_social_tariff_piggy_banks_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('social_tariff_piggy_banks', function (Blueprint $table) {
-            $table->double('savings', 15, 6)->change();
+            $table->double('savings')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_102047_update_access_rates_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_102047_update_access_rates_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('access_rates', function (Blueprint $table) {
-            $table->double('amount', 15, 6)->change();
+            $table->double('amount')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_102214_update_access_rate_payments_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_102214_update_access_rate_payments_table.php
@@ -17,8 +17,8 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('access_rate_payments', function (Blueprint $table) {
-            $table->double('debt', 15, 6)->change();
-            $table->double('unpaid_in_row', 15, 6)->change();
+            $table->double('debt')->change();
+            $table->double('unpaid_in_row')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_102507_update_asset_people_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_102507_update_asset_people_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('asset_people', function (Blueprint $table) {
-            $table->double('total_cost', 15, 6)->change();
+            $table->double('total_cost')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_102649_update_transactions_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_102649_update_transactions_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('transactions', function (Blueprint $table) {
-            $table->double('amount', 15, 6)->change();
+            $table->double('amount')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_10_102805_update_payment_histories_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_10_102805_update_payment_histories_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('payment_histories', function (Blueprint $table) {
-            $table->double('amount', 15, 6)->change();
+            $table->double('amount')->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2022_05_19_102938_update_asset_types_table.php
+++ b/src/backend/database/migrations/tenant/2022_05_19_102938_update_asset_types_table.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('asset_types', function (Blueprint $table) {
-            $table->double('price', 15, 6)->nullable()->change();
+            $table->double('price')->nullable()->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2023_03_17_234630_update_data_type_values_energies_table.php
+++ b/src/backend/database/migrations/tenant/2023_03_17_234630_update_data_type_values_energies_table.php
@@ -12,9 +12,9 @@ return new class extends Migration {
      */
     public function up() {
         Schema::connection('tenant')->table('energies', function (Blueprint $table) {
-            $table->double('used_energy_since_last', 15, 2)->default(0)->change();
-            $table->double('total_absorbed', 15, 2)->default(0)->change();
-            $table->double('absorbed_energy_since_last', 15, 2)->default(0)->change();
+            $table->double('used_energy_since_last')->default(0)->change();
+            $table->double('total_absorbed')->default(0)->change();
+            $table->double('absorbed_energy_since_last')->default(0)->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2023_03_18_014305_update_data_type_values_energies_table.php
+++ b/src/backend/database/migrations/tenant/2023_03_18_014305_update_data_type_values_energies_table.php
@@ -12,9 +12,9 @@ return new class extends Migration {
      */
     public function up() {
         Schema::connection('tenant')->table('energies', function (Blueprint $table) {
-            $table->double('used_energy_since_last', 8, 4)->default(0)->change();
-            $table->double('total_absorbed', 8, 4)->default(0)->change();
-            $table->double('absorbed_energy_since_last', 8, 4)->default(0)->change();
+            $table->double('used_energy_since_last')->default(0)->change();
+            $table->double('total_absorbed')->default(0)->change();
+            $table->double('absorbed_energy_since_last')->default(0)->change();
         });
     }
 

--- a/src/backend/database/migrations/tenant/2023_09_25_232731_update_assets_asset_people_asset_types_tables.php
+++ b/src/backend/database/migrations/tenant/2023_09_25_232731_update_assets_asset_people_asset_types_tables.php
@@ -48,7 +48,7 @@ return new class extends Migration {
             Type::addType('double', FloatType::class);
         }
         Schema::connection('tenant')->table('asset_types', function (Blueprint $table) {
-            $table->double('price', 15, 6)->nullable();
+            $table->double('price')->nullable();
         });
     }
 };


### PR DESCRIPTION
This PR removes `$total` and `$places` arguments from `double()` column definitions in migrations to align with Laravel 11's updated syntax, which now defaults to standard SQL behavior.

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
