### PR TITLE
Convert `LogListener` to actual, Listener

### DIFF
--- a/src/backend/app/Listeners/LogListener.php
+++ b/src/backend/app/Listeners/LogListener.php
@@ -3,8 +3,12 @@
 namespace App\Listeners;
 
 use App\Models\Log;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Log as ConsoleLog;
 
+// FIXME: Shouldn't this be queue-able?
+// class LogListener implements ShouldQueue {
 class LogListener {
     /**
      * @var Log
@@ -23,7 +27,10 @@ class LogListener {
         $this->log->save();
     }
 
-    public function subscribe(Dispatcher $event): void {
-        $event->listen('new.log', '\App\Listeners\LogListener@storeLog');
+    public function handle(Dispatcher $eventData): void {
+        // For debugging
+        ConsoleLog::info('Log data received:', ['data' => $eventData]);
+
+        $this->storeLog($eventData);
     }
 }

--- a/src/backend/app/Providers/EventServiceProvider.php
+++ b/src/backend/app/Providers/EventServiceProvider.php
@@ -21,6 +21,7 @@ class EventServiceProvider extends ServiceProvider {
      */
     protected $listen = [
         'App\Events\ClusterEvent' => ['App\Listeners\ClusterGeoListener'],
+        'new.log' => [LogListener::class],
     ];
 
     protected $subscribe = [
@@ -30,7 +31,6 @@ class EventServiceProvider extends ServiceProvider {
         TransactionListener::class,
         HistoryListener::class,
         PaymentPeriodListener::class,
-        LogListener::class,
         SmsListener::class,
         UserEventSubscriber::class,
     ];


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

`LogListener` is called Listener, but it's actually a subscriber. This causes confusion, for example, we cannot easily make subscribers queue-able.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
