### PR TITLE
Allow `first_payment_date` to be timestamps

### DIFF
--- a/collections/Agent App/Get Customers (App).bru
+++ b/collections/Agent App/Get Customers (App).bru
@@ -7,5 +7,5 @@ meta {
 get {
   url: {{mpm_backend_url}}/api/app/agents/customers
   body: none
-  auth: none
+  auth: inherit
 }

--- a/src/backend/app/Services/AgentSoldApplianceService.php
+++ b/src/backend/app/Services/AgentSoldApplianceService.php
@@ -6,6 +6,7 @@ use App\Models\Agent;
 use App\Models\AgentSoldAppliance;
 use App\Models\AssetPerson;
 use App\Services\Interfaces\IBaseService;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 use MPM\Device\DeviceAddressService;
@@ -156,7 +157,7 @@ class AgentSoldApplianceService implements IBaseService {
         // assign agent to appliance person
         $appliancePersonData = [
             'person_id' => $requestData['person_id'],
-            'first_payment_date' => $requestData['first_payment_date'],
+            'first_payment_date' => Carbon::parse($requestData['first_payment_date'])->toDateString(),
             'rate_count' => $requestData['tenure'],
             'total_cost' => $assignedAppliance->cost,
             'down_payment' => $requestData['down_payment'],


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Currently, the Agent app sends as ISO 8601 Timestamps for example `2025-05-27T11:33:38Z`. But the DB is set up as `DATE`.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
