### PR TITLE
Remove `original_agent` backport

### DIFF
--- a/src/backend/app/Services/AgentTransactionService.php
+++ b/src/backend/app/Services/AgentTransactionService.php
@@ -42,15 +42,6 @@ class AgentTransactionService implements IBaseService {
 
         $transactions = $limit ? $query->paginate($limit) : $query->get();
 
-        // For backwards compatibility with the Agent App we are artificially adding
-        // the column `original_agent`.
-        // TODO: Confirm the app is actually using `original_agent`
-        // -> If yes, move to `original_transaction`
-        // -> If no, remove this code
-        $transactions->each(function ($transaction) {
-            $transaction->setAttribute('original_agent', $transaction->originalTransaction);
-        });
-
         return $transactions;
     }
 
@@ -72,15 +63,6 @@ class AgentTransactionService implements IBaseService {
             ->whereHas('device', fn ($q) => $q->whereIn('device_serial', $customerDeviceSerials))
             ->latest()
             ->paginate();
-
-        // For backwards compatibility with the Agent App we are artificially adding
-        // the column `original_agent`.
-        // TODO: Confirm the app is actually using `original_agent`
-        // -> If yes, move to `original_transaction`
-        // -> If no, remove this code
-        $transactions->each(function ($transaction) {
-            $transaction->setAttribute('original_agent', $transaction->originalTransaction);
-        });
 
         return $transactions;
     }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Parity change to https://github.com/EnAccess/micropowermanager-agent-app/releases/tag/v1.6.0

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
