### PR TITLE
Replace custom health route with laravel's built-in health route

### DIFF
--- a/src/backend/app/Providers/RouteServiceProvider.php
+++ b/src/backend/app/Providers/RouteServiceProvider.php
@@ -21,8 +21,6 @@ class RouteServiceProvider extends ServiceProvider {
      * @return void
      */
     public function map() {
-        $this->mapHealthRoute();
-
         $this->mapApiRoutes();
         $this->mapWebRoutes();
     }
@@ -50,18 +48,5 @@ class RouteServiceProvider extends ServiceProvider {
         Route::prefix('api')
             ->middleware('api')
             ->group(base_path('routes/api.php'));
-    }
-
-    /**
-     * Define healthcheck routes for the application.
-     *
-     * Using this as a backport for Laravel 11 healthcheck feature.
-     *
-     * @return void
-     */
-    protected function mapHealthRoute() {
-        Route::get('/up', function () {
-            return response()->json(['status' => 'OK'], 200);
-        });
     }
 }

--- a/src/backend/bootstrap/app.php
+++ b/src/backend/bootstrap/app.php
@@ -23,7 +23,6 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         channels: __DIR__.'/../routes/channels.php',
-        // health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(UserDefaultDatabaseConnectionMiddleware::class);

--- a/src/backend/bootstrap/app.php
+++ b/src/backend/bootstrap/app.php
@@ -23,6 +23,7 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         channels: __DIR__.'/../routes/channels.php',
+        health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(UserDefaultDatabaseConnectionMiddleware::class);


### PR DESCRIPTION
Makes progress on: #745 

Laravel 11 now has built-in health route. This PR removes custom health route in favor of Laravel's built-in health route.

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
