### PR TITLE
Fix Error thrown on empty ProtectedPagesPassword

### DIFF
--- a/src/backend/app/Services/ProtectedPageService.php
+++ b/src/backend/app/Services/ProtectedPageService.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Crypt;
 class ProtectedPageService implements IBaseService {
     public function __construct(private ProtectedPage $protectedPage) {}
 
-    public function compareProtectedPagePassword(MainSettings $mainSettings, string $password): bool {
+    public function compareProtectedPagePassword(MainSettings $mainSettings, ?string $password): bool {
         return Crypt::decrypt($mainSettings->protected_page_password) === $password;
     }
 


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

When a user just clicks the enter button on PPP popup without entering a password, it throws an error in the logs. But it's just normal flow.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
