### PR TITLE
Fix `SQLSTATE[HY000]: General error: 1364 Field 'api_url' doesn't hav…

### DIFF
--- a/docs/installation/environment-variables.md
+++ b/docs/installation/environment-variables.md
@@ -145,9 +145,10 @@ Find below a reference of configurations which are required if the corresponding
 
 For detailed information see [SunKing Developer Documentation](https://sunking.com/)
 
-| Environment Variable | Default                            | Description                                                                      |
-| -------------------- | ---------------------------------- | -------------------------------------------------------------------------------- |
-| `SUNKING_API_URL`    | **Required** (when plugin is used) | SunKing API URL. For example `https://dev.assetcontrol.central.glp apps.com/v2`. |
+| Environment Variable       | Default                                                                              | Description                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `SUNKING_AUTH_DEFAULT_URL` | `https://auth.central.glpapps.com/auth/realms/glp-dev/protocol/openid-connect/token` | Default authorisation URL used when tenants activate the SunKing plugin on the instance of MicroPowerManager. |
+| `SUNKING_API_DEFAULT_URL`  | `https://dev.assetcontrol.central.glpapps.com/v2`                                    | Default API URL used when tenants activate the SunKing plugin on the instance of MicroPowerManager.           |
 
 #### WaveMoney
 

--- a/src/backend/config/services.php
+++ b/src/backend/config/services.php
@@ -38,7 +38,8 @@ return [
         'url' => env('BINGMAP_API_URL', 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial?key='),
     ],
     'sunKing' => [
-        'url' => env('SUNKING_API_URL'),
+        'default_auth_url' => env('SUNKING_DEFAULT_AUTH_URL', 'https://auth.central.glpapps.com/auth/realms/glp-dev/protocol/openid-connect/token'),
+        'default_api_url' => env('SUNKING_DEFAULT_API_URL', 'https://dev.assetcontrol.central.glpapps.com/v2'),
     ],
     'waveMoney' => [
         'url' => env('WAVEMONEY_API_URL'),

--- a/src/backend/database/migrations/tenant/2025_08_07_124254_alter_sun_king_api_credentials_column_defaults.php
+++ b/src/backend/database/migrations/tenant/2025_08_07_124254_alter_sun_king_api_credentials_column_defaults.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::connection('tenant')->table('sun_king_api_credentials', function (Blueprint $table) {
+            $table->string('auth_url')->default(config('services.sunKing.default_auth_url'))->change();
+            $table->string('api_url')->default(config('services.sunKing.default_api_url'))->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::connection('tenant')->table('sun_king_api_credentials', function (Blueprint $table) {
+            $table->string('auth_url')->default('https://auth.central.glpapps.com/auth/realms/glp-dev/protocol/openid-connect/token')->change();
+            $table->string('api_url')->default(config('services.sunKing.url'))->change();
+        });
+    }
+};


### PR DESCRIPTION
…e a default value` when enabling SunKing plugin

<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

When users first enable the SunKing plugin yields the following error:

```
SQLSTATE[HY000]: General error: 1364 Field 'api_url' doesn't have a default value (Connection: tenant, SQL: insert into sun_king_api_credentials (client_id, client_secret, updated_at, created_at) values (?, ?, 2025-08-07 09:08:55, 2025-08-07 09:08:55))
```

Is is particular user experience when users select the SunKing plugin on company registration as MPM then displays "There was a problem on company registration" error.

Fixing this by setting a default value.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
