### PR TITLE
enforce birthday and gender fields

### DIFF
--- a/src/frontend/src/modules/Client/AddClientModal.vue
+++ b/src/frontend/src/modules/Client/AddClientModal.vue
@@ -89,21 +89,40 @@
                 </md-field>
               </div>
               <div class="md-layout-item md-size-50 md-small-size-100">
-                <md-datepicker
-                  name="birthDate"
-                  md-immediately
-                  v-model="personService.person.birthDate"
-                  :md-close-on-blur="false"
+                <md-field
+                  :class="{
+                    'md-invalid': errors.has('customer-add-form.birthDate'),
+                  }"
                 >
-                  <label for="birth-date">{{ $tc("words.birthday") }} :</label>
-                </md-datepicker>
+                  <md-datepicker
+                    id="birth-date"
+                    name="birthDate"
+                    md-immediately
+                    v-model="personService.person.birthDate"
+                    v-validate="'required|date_format:YYYY-MM-DD'"
+                    :data-vv-as="$tc('words.birthday')"
+                    :md-close-on-blur="false"
+                  >
+                    <label for="birth-date">
+                      {{ $tc("words.birthday") }} :
+                    </label>
+                  </md-datepicker>
+                  <span class="md-error">
+                    {{ errors.first("customer-add-form.birthDate") }}
+                  </span>
+                </md-field>
               </div>
               <div class="md-layout-item md-size-50 md-small-size-100">
-                <md-field>
+                <md-field
+                  :class="{
+                    'md-invalid': errors.has('customer-add-form.gender'),
+                  }"
+                >
                   <label for="gender">{{ $tc("words.gender") }} :</label>
                   <md-select
                     name="gender"
                     id="gender"
+                    v-validate="'required'"
                     v-model="personService.person.gender"
                   >
                     <md-option value="male">
@@ -113,6 +132,9 @@
                       {{ $tc("words.female") }}
                     </md-option>
                   </md-select>
+                  <span class="md-error">
+                    {{ errors.first("customer-add-form.gender") }}
+                  </span>
                 </md-field>
               </div>
               <div class="md-layout-item md-size-50 md-small-size-100">


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

The birthday field and gender fields are now enforce on the client to prevent server error on the backend with "invalid date" insert to the database. 

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
