### PR TITLE
Add `composer install` to Queue Worker Prod container

### DIFF
--- a/docker/DockerfileQueueWorkerProd
+++ b/docker/DockerfileQueueWorkerProd
@@ -67,5 +67,9 @@ RUN chmod -R 775 /var/www/html/storage
 COPY docker/entrypoint-queue-worker.sh /usr/local/bin/entrypoint-queue-worker-prod.sh
 RUN chmod +x /usr/local/bin/entrypoint-queue-worker-prod.sh
 
+# install MicroPowerManager
+WORKDIR /var/www/html
+RUN composer install --no-dev --optimize-autoloader
+
 # define entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint-queue-worker-prod.sh"]


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

In the Queue Worker Prod container the actual `composer install` command wasn't executed, leading to the Queue Worker container failing when run in prod mode.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
