### PR TITLE
Fix `kustomize` deploy scripts

### DIFF
--- a/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
@@ -17,6 +17,8 @@ images:
     newTag: 0.0.48
   - name: enaccess/micropowermanager-scheduler:latest
     newTag: 0.0.48
+  - name: enaccess/micropowermanager-queue-worker:latest
+    newTag: 0.0.48
 
 patches:
   - path: configmap-cloud-backend.yaml

--- a/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
@@ -15,6 +15,8 @@ images:
     newTag: latest
   - name: enaccess/micropowermanager-scheduler:latest
     newTag: latest
+  - name: enaccess/micropowermanager-queue-worker:latest
+    newTag: latest
 
 patches:
   # Setting a static IP address for our load balancer, see


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Adding `enaccess/micropowermanager-queue-worker:latest` to our `kustomize` scripts. Else it will always be stuck with `latest` and not re-deploy on new releases.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
