### PR TITLE
Simplify Docker filesystem permission handling

### DIFF
--- a/docker/DockerfileBackendDev
+++ b/docker/DockerfileBackendDev
@@ -39,9 +39,9 @@ RUN mv composer.phar /usr/local/bin/composer
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_enable=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_autostart=0 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_connephpct_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.remote_connect_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_port=9000 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
+    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
 
 # configure PHP
 COPY docker/config/php/php.ini /usr/local/etc/php/php.ini
@@ -65,13 +65,10 @@ RUN chmod +x /usr/local/bin/entrypoint-backend-dev.sh
 # but instead run `composer install` at runtime by adding it to the entrypoint script.
 # This way, we will ensure that local changes are exposed in the container and
 # benefit from hot-reloading.
-RUN sed -i '1a\
+RUN sed -i '/^# DEVCONTAINER PLACEHOLDER (DO NOT REMOVE THIS LINE)$/a\
 echo "Installing MicroPowerManager in development mode..."\n\
 cd /var/www/html\n\
-echo "Setting up storage permissions..."\n\
-chown -R www-data:www-data /var/www/html/storage\n\
-chmod -R 775 /var/www/html/storage\n\
-composer install' /usr/local/bin/entrypoint-backend-dev.sh
+composer install\n' /usr/local/bin/entrypoint-backend-dev.sh
 
 # define entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint-backend-dev.sh"]

--- a/docker/DockerfileBackendProd
+++ b/docker/DockerfileBackendProd
@@ -52,8 +52,6 @@ RUN a2enmod rewrite
 
 # get MicroPowerManager source code and addition files
 COPY src/backend /var/www/html
-RUN chown -R www-data:www-data /var/www/html
-RUN chmod -R 775 /var/www/html/storage
 
 # indicate storage directory to persist data
 VOLUME ["/var/www/html/storage"]

--- a/docker/DockerfileQueueWorkerDev
+++ b/docker/DockerfileQueueWorkerDev
@@ -43,9 +43,9 @@ RUN mv composer.phar /usr/local/bin/composer
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_enable=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_autostart=0 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_connephpct_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.remote_connect_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_port=9000 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
+    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
 
 # configure PHP
 COPY docker/config/php/php.ini /usr/local/etc/php/php.ini
@@ -74,10 +74,10 @@ RUN chmod +x /usr/local/bin/entrypoint-queue-worker-dev.sh
 # but instead run `composer install` at runtime by adding it to the entrypoint script.
 # This way, we will ensure that local changes are exposed in the container and
 # benefit from hot-reloading.
-RUN sed -i '1a\
+RUN sed -i '/^# DEVCONTAINER PLACEHOLDER (DO NOT REMOVE THIS LINE)$/a\
 echo "Installing MicroPowerManager in development mode..."\n\
 cd /var/www/html\n\
-composer install' /usr/local/bin/entrypoint-queue-worker-dev.sh
+composer install\n' /usr/local/bin/entrypoint-queue-worker-dev.sh
 
 # define entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint-queue-worker-dev.sh"]

--- a/docker/DockerfileQueueWorkerProd
+++ b/docker/DockerfileQueueWorkerProd
@@ -43,9 +43,9 @@ RUN mv composer.phar /usr/local/bin/composer
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_enable=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_autostart=0 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_connephpct_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.remote_connect_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_port=9000 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
+    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
 
 # configure PHP
 COPY docker/config/php/php.ini /usr/local/etc/php/php.ini
@@ -61,8 +61,6 @@ RUN touch /etc/supervisor/logs/horizon/err.log
 
 # get MicroPowerManager source code and addition files
 COPY src/backend /var/www/html
-RUN chown -R www-data:www-data /var/www/html
-RUN chmod -R 775 /var/www/html/storage
 
 # indicate storage directory to persist data
 VOLUME ["/var/www/html/storage"]

--- a/docker/DockerfileSchedulerDev
+++ b/docker/DockerfileSchedulerDev
@@ -43,9 +43,9 @@ RUN mv composer.phar /usr/local/bin/composer
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_enable=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_autostart=0 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_connephpct_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.remote_connect_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_port=9000 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
+    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
 
 # configure PHP
 COPY docker/config/php/php.ini /usr/local/etc/php/php.ini
@@ -71,10 +71,10 @@ RUN chmod +x /usr/local/bin/entrypoint-scheduler-dev.sh
 # but instead run `composer install` at runtime by adding it to the entrypoint script.
 # This way, we will ensure that local changes are exposed in the container and
 # benefit from hot-reloading.
-RUN sed -i '1a\
+RUN sed -i '/^# DEVCONTAINER PLACEHOLDER (DO NOT REMOVE THIS LINE)$/a\
 echo "Installing MicroPowerManager in development mode..."\n\
 cd /var/www/html\n\
-composer install' /usr/local/bin/entrypoint-scheduler-dev.sh
+composer install\n' /usr/local/bin/entrypoint-scheduler-dev.sh
 
 # define entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint-scheduler-dev.sh"]

--- a/docker/DockerfileSchedulerProd
+++ b/docker/DockerfileSchedulerProd
@@ -43,9 +43,9 @@ RUN mv composer.phar /usr/local/bin/composer
 RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_enable=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_autostart=0 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_connephpct_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    echo xdebug.remote_connect_back=1 >> /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_port=9000 >> /usr/local/etc/php/conf.d/xdebug.ini; \
-    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
+    echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
 
 # configure PHP
 COPY docker/config/php/php.ini /usr/local/etc/php/php.ini
@@ -58,8 +58,6 @@ RUN touch /var/log/cron.log
 
 # get MicroPowerManager source code and addition files
 COPY src/backend /var/www/html
-RUN chown -R www-data:www-data /var/www/html
-RUN chmod -R 775 /var/www/html/storage
 
 # indicate storage directory to persist data
 VOLUME ["/var/www/html/storage"]

--- a/docker/entrypoint-backend.sh
+++ b/docker/entrypoint-backend.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+echo "Ensure correct filesystem permissions are set..."
+chown -R www-data:www-data /var/www/html
+chmod -R 775 /var/www/html/storage
+
+# DEVCONTAINER PLACEHOLDER (DO NOT REMOVE THIS LINE)
+
 cd /var/www/html
 
 echo "Running MicroPowerManager central migrations..."

--- a/docker/entrypoint-queue-worker.sh
+++ b/docker/entrypoint-queue-worker.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
+echo "Ensure correct filesystem permissions are set..."
+chown -R www-data:www-data /var/www/html
+chmod -R 775 /var/www/html/storage
+
+# DEVCONTAINER PLACEHOLDER (DO NOT REMOVE THIS LINE)
+
 /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/docker/entrypoint-scheduler.sh
+++ b/docker/entrypoint-scheduler.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+echo "Ensure correct filesystem permissions are set..."
+chown -R www-data:www-data /var/www/html
+chmod -R 775 /var/www/html/storage
+
+# DEVCONTAINER PLACEHOLDER (DO NOT REMOVE THIS LINE)
+
 printenv > /etc/environment
 
 echo "cron starting..."


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Introducing volumes for `storage` added a small complexity that we now have to deal with filesystem permissions for the MPM source code (and the included `storage` directory). Currently, they are all over the place. Sometimes in the Dockerfile (for prod containers), sometime in a `sed` command in the Dockerfile. 

This PR tries to simplify this by moving all permission handling for the MPM source into the entry point files. This has the side benefit that our Prod and Dev Dockerfiles look even more similar now:

<img width="2135" height="566" alt="image" src="https://github.com/user-attachments/assets/4ea24372-6134-4c92-92c2-54bb065fa6ac" />

Highlighting that they should be as similar as possible.

Also, noticed some typos `remote_connephpct_back`.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
