### PR TITLE
Fix report files created as root

### DIFF
--- a/docker/DockerfileBackendDev
+++ b/docker/DockerfileBackendDev
@@ -71,6 +71,7 @@ cd /var/www/html\n\
 composer install\n' /usr/local/bin/entrypoint-backend-dev.sh
 
 # define entrypoint
+USER www-data
 ENTRYPOINT ["/usr/local/bin/entrypoint-backend-dev.sh"]
 
 EXPOSE 80

--- a/docker/DockerfileBackendProd
+++ b/docker/DockerfileBackendProd
@@ -64,6 +64,7 @@ WORKDIR /var/www/html
 RUN composer install --no-dev --optimize-autoloader
 
 # define entrypoint
+USER www-data
 ENTRYPOINT ["/usr/local/bin/entrypoint-backend-prod.sh"]
 
 EXPOSE 80

--- a/docker/DockerfileQueueWorkerDev
+++ b/docker/DockerfileQueueWorkerDev
@@ -80,4 +80,5 @@ cd /var/www/html\n\
 composer install\n' /usr/local/bin/entrypoint-queue-worker-dev.sh
 
 # define entrypoint
+USER www-data
 ENTRYPOINT ["/usr/local/bin/entrypoint-queue-worker-dev.sh"]

--- a/docker/DockerfileQueueWorkerProd
+++ b/docker/DockerfileQueueWorkerProd
@@ -73,4 +73,5 @@ WORKDIR /var/www/html
 RUN composer install --no-dev --optimize-autoloader
 
 # define entrypoint
+USER www-data
 ENTRYPOINT ["/usr/local/bin/entrypoint-queue-worker-prod.sh"]

--- a/docker/DockerfileSchedulerDev
+++ b/docker/DockerfileSchedulerDev
@@ -77,4 +77,5 @@ cd /var/www/html\n\
 composer install\n' /usr/local/bin/entrypoint-scheduler-dev.sh
 
 # define entrypoint
+USER www-data
 ENTRYPOINT ["/usr/local/bin/entrypoint-scheduler-dev.sh"]

--- a/docker/DockerfileSchedulerProd
+++ b/docker/DockerfileSchedulerProd
@@ -70,4 +70,5 @@ WORKDIR /var/www/html
 RUN composer install --no-dev --optimize-autoloader
 
 # define entrypoint
+USER www-data
 ENTRYPOINT ["/usr/local/bin/entrypoint-scheduler-prod.sh"]

--- a/docker/config/cron/crontab
+++ b/docker/config/cron/crontab
@@ -1,2 +1,2 @@
-* * * * * root /usr/local/bin/php -q -f /var/www/html/artisan schedule:run  >> /var/log/cron.log 2>&1
+* * * * * www-data /usr/local/bin/php -q -f /var/www/html/artisan schedule:run  >> /var/log/cron.log 2>&1
 # Don’t remove the empty line at the end of this file. It is required to run the cron job


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

We are still encountering 

```
/var/www/html/storage/monthly/monthly-tumbe-village-2025-08-01-2025-08-27.xlsx\" does not exist
```

errors in the Demo environment. This is mostly related to reports files created by the scheduler as `root`.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
