### PR TITLE
Fix report generation

### DIFF
--- a/src/backend/app/Models/Device.php
+++ b/src/backend/app/Models/Device.php
@@ -6,8 +6,10 @@ use App\Models\Address\Address;
 use App\Models\Base\BaseModel;
 use App\Models\Meter\Meter;
 use App\Models\Person\Person;
+use App\Models\Transaction\Transaction;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -61,5 +63,12 @@ class Device extends BaseModel {
      */
     public function appliance(): HasOne {
         return $this->hasOne(Asset::class, 'device_serial', 'device_serial');
+    }
+
+    /**
+     * @return HasMany<Transaction, $this>
+     */
+    public function transactions(): HasMany {
+        return $this->hasMany(Transaction::class, 'message', 'device_serial');
     }
 }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This https://github.com/EnAccess/micropowermanager/pull/868/files#diff-7c10d41439a5e9f36bd33167f8bf961957aa1e2df721e6cacc818f4ce797aa1c introduced a "change". Before

```
if ($transaction->device->device->device_type === Meter::RELATION_NAME)
```

would alway be true. After this fix, we actually execute the code block in the body of the `if`-statement. However, this code is broken. Fixing it here.

In particular, due to this filtering

```
        $transactions = $this->transaction::with([
            'device.device' => function ($query) {
                $query->select('id'); // Only load necessary fields for MorphTo
            },
        ])
```

None of the related model like `tariff`, `connectionType` are resolvable later. 

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
