### PR TITLE
Change `storage` PVC to `ReadWriteMany`

### DIFF
--- a/k8s/base/aws_eks/deployments/mpm-storage-pvc.yaml
+++ b/k8s/base/aws_eks/deployments/mpm-storage-pvc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: mpm-storage-pvc
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 10Gi
-  storageClassName: gp2  # AWS EBS storage class
+  storageClassName: gp2 # AWS EBS storage class

--- a/k8s/base/gcp_gke/storage-pvc.yaml
+++ b/k8s/base/gcp_gke/storage-pvc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: storage-pvc
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 10Gi
-  storageClassName: standard-rwo  # GCP standard storage class
+  storageClassName: standard-rwo # GCP standard storage class


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

We see some Warnings like this one:

```
Multi-Attach error for volume "pvc-e6b2931b-f50c-458d-94c5-f3237338e435" Volume is already use │
│ d by pod(s) mpm-backend-58666658fc-85h5g
```

It still works, because the pods are run on the same node, see: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
