### PR TITLE
Add `failed_jobs` table

### DIFF
--- a/src/backend/database/migrations/2025_09_25_105955_create_failed_jobs_table.php
+++ b/src/backend/database/migrations/2025_09_25_105955_create_failed_jobs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('failed_jobs');
+    }
+};


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Fixes

```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'micro_power_manager.failed_jobs' doesn't exist (Connection: micro_power_manager, SQL: insert into failed_jobs (connection, queue, payload, exception, failed_at) values
```

After https://github.com/EnAccess/micropowermanager/pull/826 our jobs a now actually running async. There for we need the `failed_jobs` table, if there is a problem with the queue. See https://laravel.com/docs/12.x/queues#dealing-with-failed-jobs


### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
