### PR TITLE
phone icon is now correctly aligned with the field

### DIFF
--- a/src/frontend/src/modules/Settings/UserManagement/EditUser.vue
+++ b/src/frontend/src/modules/Settings/UserManagement/EditUser.vue
@@ -6,12 +6,19 @@
           <md-card>
             <md-card-content class="md-layout md-gutter">
               <div class="md-layout-item md-size-50 md-small-size-100">
-                <md-field :class="{
-                  'md-invalid': errors.has('Edit-Form.' + $tc('words.name')),
-                }">
+                <md-field
+                  :class="{
+                    'md-invalid': errors.has('Edit-Form.' + $tc('words.name')),
+                  }"
+                >
                   <label>{{ $tc("words.name") }}</label>
-                  <md-input disabled v-model="user.name" v-validate="'required|min:2|max:20'" :name="$tc('words.name')"
-                    id="name" />
+                  <md-input
+                    disabled
+                    v-model="user.name"
+                    v-validate="'required|min:2|max:20'"
+                    :name="$tc('words.name')"
+                    id="name"
+                  />
                   <md-icon>create</md-icon>
                   <span class="md-error">
                     {{ errors.first("Edit-Form." + $tc("words.name")) }}
@@ -19,14 +26,31 @@
                 </md-field>
               </div>
               <div class="md-layout-item md-size-50 md-small-size-100">
-                <md-field :class="{ 'md-invalid': !phone.valid && firstStepClicked }">
-                  <vue-tel-input id="phone" :validCharactersOnly="true" mode="international"
-                    invalidMsg="invalid phone number" :disabledFetchingCountry="false" :disabledFormatting="false"
-                    placeholder="Enter a phone number" :required="true"
-                    :preferredCountries="['TZ', 'CM', 'KE', 'NG', 'UG']" autocomplete="off" :name="$tc('words.phone')"
-                    enabledCountryCode="true" v-model="user.phone" @validate="validatePhone" @input="onPhoneInput" />
+                <md-field
+                  :class="{ 'md-invalid': !phone.valid && firstStepClicked }"
+                >
+                  <vue-tel-input
+                    id="phone"
+                    :validCharactersOnly="true"
+                    mode="international"
+                    invalidMsg="invalid phone number"
+                    :disabledFetchingCountry="false"
+                    :disabledFormatting="false"
+                    placeholder="Enter a phone number"
+                    :required="true"
+                    :preferredCountries="['TZ', 'CM', 'KE', 'NG', 'UG']"
+                    autocomplete="off"
+                    :name="$tc('words.phone')"
+                    enabledCountryCode="true"
+                    v-model="user.phone"
+                    @validate="validatePhone"
+                    @input="onPhoneInput"
+                  />
                   <md-icon>phone</md-icon>
-                  <span v-if="!phone.valid && firstStepClicked" class="md-error">
+                  <span
+                    v-if="!phone.valid && firstStepClicked"
+                    class="md-error"
+                  >
                     invalid phone number
                   </span>
                 </md-field>
@@ -39,13 +63,20 @@
                 </md-field>
               </div>
               <div class="md-layout-item md-size-50 md-small-size-100">
-                <md-field :class="{
-                  'md-invalid': errors.has('Edit-Form.' + $tc('words.city')),
-                }">
+                <md-field
+                  :class="{
+                    'md-invalid': errors.has('Edit-Form.' + $tc('words.city')),
+                  }"
+                >
                   <label for="city">
                     {{ $tc("words.city") }}
                   </label>
-                  <md-select v-model="selectedCity" :name="$tc('words.city')" id="city" v-validate="'required'">
+                  <md-select
+                    v-model="selectedCity"
+                    :name="$tc('words.city')"
+                    id="city"
+                    v-validate="'required'"
+                  >
                     <md-option v-for="c in cities" :key="c.id" :value="c.id">
                       {{ c.name }}
                     </md-option>


### PR DESCRIPTION
Fix: Corrected Phone Icon Misalignment and Duplication on Edit User Page
Brief summary of the change made

This PR fixes the issue where the phone icon on the Edit User Page was misaligned and displayed twice.
Now, the phone icon is properly aligned with the corresponding input field and only a single instance of it is shown.

closes: #987 

<img width="1626" height="429" alt="image" src="https://github.com/user-attachments/assets/bce95dbf-9266-4e34-95ff-93b37a167de5" />


Please have a look and consider merging it, if you need further changes in this, i'll be happy to make them.
