### PR TITLE
Reduce the size on the deployed Filestorage drive on GCP

### DIFF
--- a/k8s/base/gcp_gke/storage-pvc.yaml
+++ b/k8s/base/gcp_gke/storage-pvc.yaml
@@ -7,5 +7,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 10Gi
+      storage: 100Gi
   storageClassName: standard-rwx


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This is an odd one. The goal of this PR is to **reduce** the size of the deployed Filestorage disk by the PVC.

The problem is that 10GB is an illegal deploy size as per: https://cloud.google.com/filestore/docs/service-tiers#overview

As a result `storage: 10Gi` actually provisions a 1Ti disk. Hence setting it to 100Gi which is the minimum here.

> [!WARNING]
> PVC size reductions are not supported via Kubernetes API. Hence for existing clusters the PVC needs to be manually deleted and re-deployed.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
