### PR TITLE
Deprecate package BaseModels, migrate to shared root BaseModel, remove redundancies

### DIFF
--- a/src/backend/packages/inensus/bulk-registration/src/Models/CsvData.php
+++ b/src/backend/packages/inensus/bulk-registration/src/Models/CsvData.php
@@ -4,6 +4,6 @@ namespace Inensus\BulkRegistration\Models;
 
 use App\Models\Base\BaseModel;
 
-class CsvData extends \App\Models\Base\BaseModel {
+class CsvData extends BaseModel {
     protected $table = 'bulk_registration_csv_datas';
 }

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmCredential.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmCredential.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmCredential extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmCredential extends BaseModel {
     protected $table = 'sm_api_credentials';
 }

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmCustomer.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmCustomer.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\SparkMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Person\Person;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property Person $mpmPerson
  * @property SmSite $site
  */
-class SmCustomer extends \App\Models\Base\BaseModel {
+class SmCustomer extends BaseModel {
     protected $table = 'sm_customers';
 
     public function mpmPerson(): BelongsTo {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmMeterModel.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmMeterModel.php
@@ -2,10 +2,11 @@
 
 namespace Inensus\SparkMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Meter\MeterType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class SmMeterModel extends \App\Models\Base\BaseModel {
+class SmMeterModel extends BaseModel {
     protected $table = 'sm_meter_models';
 
     public function meterType(): BelongsTo {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmOrganization.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmOrganization.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmOrganization extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmOrganization extends BaseModel {
     protected $table = 'sm_organizations';
 }

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSalesAccount.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSalesAccount.php
@@ -2,12 +2,13 @@
 
 namespace Inensus\SparkMeter\Models;
 
+use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property SmSite $site
  */
-class SmSalesAccount extends \App\Models\Base\BaseModel {
+class SmSalesAccount extends BaseModel {
     protected $table = 'sm_sales_accounts';
 
     public function site(): BelongsTo {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSetting.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSetting.php
@@ -2,9 +2,10 @@
 
 namespace Inensus\SparkMeter\Models;
 
+use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class SmSetting extends \App\Models\Base\BaseModel {
+class SmSetting extends BaseModel {
     protected $table = 'sm_settings';
 
     public function setting(): MorphTo {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSite.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSite.php
@@ -2,13 +2,14 @@
 
 namespace Inensus\SparkMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\MiniGrid;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property MiniGrid $mpmMiniGrid
  */
-class SmSite extends \App\Models\Base\BaseModel {
+class SmSite extends BaseModel {
     protected $table = 'sm_sites';
 
     public function mpmMiniGrid(): BelongsTo {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSmsBody.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSmsBody.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmSmsBody extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmSmsBody extends BaseModel {
     protected $table = 'sm_sms_bodies';
 }

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSmsFeedbackWord.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSmsFeedbackWord.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmSmsFeedbackWord extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmSmsFeedbackWord extends BaseModel {
     protected $table = 'sm_sms_feedback_words';
 }

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSmsNotifiedCustomer.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSmsNotifiedCustomer.php
@@ -2,9 +2,10 @@
 
 namespace Inensus\SparkMeter\Models;
 
+use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class SmSmsNotifiedCustomer extends \App\Models\Base\BaseModel {
+class SmSmsNotifiedCustomer extends BaseModel {
     protected $table = 'sm_sms_notified_customers';
 
     public function notify(): MorphTo {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSmsSetting.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSmsSetting.php
@@ -2,7 +2,9 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmSmsSetting extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmSmsSetting extends BaseModel {
     protected $table = 'sm_sms_settings';
 
     public function setting() {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSmsVariableDefaultValue.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSmsVariableDefaultValue.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmSmsVariableDefaultValue extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmSmsVariableDefaultValue extends BaseModel {
     protected $table = 'sm_sms_variable_default_values';
 }

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSyncAction.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSyncAction.php
@@ -2,7 +2,9 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmSyncAction extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmSyncAction extends BaseModel {
     protected $table = 'sm_sync_actions';
 
     public function synSetting() {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmSyncSetting.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmSyncSetting.php
@@ -2,7 +2,9 @@
 
 namespace Inensus\SparkMeter\Models;
 
-class SmSyncSetting extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SmSyncSetting extends BaseModel {
     protected $table = 'sm_sync_settings';
 
     public function syncAction() {

--- a/src/backend/packages/inensus/spark-meter/src/Models/SmTariff.php
+++ b/src/backend/packages/inensus/spark-meter/src/Models/SmTariff.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\SparkMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Meter\MeterTariff;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property MeterTariff $mpmTariff
  * @property SmSite      $site
  */
-class SmTariff extends \App\Models\Base\BaseModel {
+class SmTariff extends BaseModel {
     protected $table = 'sm_tariffs';
 
     public function mpmTariff(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaAgent.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaAgent.php
@@ -3,13 +3,14 @@
 namespace Inensus\SteamaMeter\Models;
 
 use App\Models\Agent;
+use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property Agent      $mpmAgent
  * @property SteamaSite $site
  */
-class SteamaAgent extends \App\Models\Base\BaseModel {
+class SteamaAgent extends BaseModel {
     protected $table = 'steama_agents';
 
     public function mpmAgent(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaAssetRatesPaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaAssetRatesPaymentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaAssetRatesPaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaAssetRatesPaymentPlan extends BaseModel {
     protected $table = 'steama_asset_rates_payment_plans';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaCredential.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaCredential.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaCredential extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaCredential extends BaseModel {
     protected $table = 'steama_credentials';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaCustomer.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaCustomer.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Person\Person;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property Person         $mpmPerson
  * @property SteamaUserType $userType
  */
-class SteamaCustomer extends \App\Models\Base\BaseModel {
+class SteamaCustomer extends BaseModel {
     protected $table = 'steama_customers';
 
     public function mpmPerson(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaCustomerBasisPaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaCustomerBasisPaymentPlan.php
@@ -2,10 +2,11 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class SteamaCustomerBasisPaymentPlan extends \App\Models\Base\BaseModel {
+class SteamaCustomerBasisPaymentPlan extends BaseModel {
     protected $table = 'steama_customer_basis_payment_plans';
 
     public function customer(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaCustomerBasisTimeOfUsage.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaCustomerBasisTimeOfUsage.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaCustomerBasisTimeOfUsage extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaCustomerBasisTimeOfUsage extends BaseModel {
     protected $table = 'create_steama_customer_basis_time_of_usages';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaFlatRatePaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaFlatRatePaymentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaFlatRatePaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaFlatRatePaymentPlan extends BaseModel {
     protected $table = 'steama_flat_rate_payment_plans';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaHybridPaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaHybridPaymentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaHybridPaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaHybridPaymentPlan extends BaseModel {
     protected $table = 'steama_hybrid_payment_plans';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaMeter.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaMeter.php
@@ -2,10 +2,11 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Meter\Meter;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class SteamaMeter extends \App\Models\Base\BaseModel {
+class SteamaMeter extends BaseModel {
     protected $table = 'steama_meters';
 
     public function mpmMeter(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaMeterType.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaMeterType.php
@@ -2,10 +2,11 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Meter\MeterType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class SteamaMeterType extends \App\Models\Base\BaseModel {
+class SteamaMeterType extends BaseModel {
     protected $table = 'steama_meter_types';
 
     public function mpmMeterType(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaMinimumTopUpRequirementsPaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaMinimumTopUpRequirementsPaymentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaMinimumTopUpRequirementsPaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaMinimumTopUpRequirementsPaymentPlan extends BaseModel {
     protected $table = 'steama_minimum_top_up_requirements_payment_plans';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaPerKwhPaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaPerKwhPaymentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaPerKwhPaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaPerKwhPaymentPlan extends BaseModel {
     protected $table = 'steama_per_kwh_payment_plans';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSetting.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSetting.php
@@ -5,7 +5,7 @@ namespace Inensus\SteamaMeter\Models;
 use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class SteamaSetting extends \App\Models\Base\BaseModel {
+class SteamaSetting extends BaseModel {
     protected $table = 'steama_settings';
 
     public function setting(): MorphTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSite.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSite.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\MiniGrid;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -12,7 +13,7 @@ use Illuminate\Support\Collection;
  * @property Collection<int, SteamaSiteLevelPaymentPlan> $paymentPlans
  * @property Collection<int, SteamaAgent>                $agents
  */
-class SteamaSite extends \App\Models\Base\BaseModel {
+class SteamaSite extends BaseModel {
     protected $table = 'steama_sites';
 
     public function mpmMiniGrid(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSiteLevelPaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSiteLevelPaymentPlan.php
@@ -2,7 +2,9 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaSiteLevelPaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaSiteLevelPaymentPlan extends BaseModel {
     protected $table = 'steama_site_level_payment_plans';
 
     public function site() {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSiteLevelPaymentPlanType.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSiteLevelPaymentPlanType.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaSiteLevelPaymentPlanType extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaSiteLevelPaymentPlanType extends BaseModel {
     protected $table = 'steama_site_level_payment_plan_types';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsBody.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsBody.php
@@ -4,6 +4,6 @@ namespace Inensus\SteamaMeter\Models;
 
 use App\Models\Base\BaseModel;
 
-class SteamaSmsBody extends \App\Models\Base\BaseModel {
+class SteamaSmsBody extends BaseModel {
     protected $table = 'steama_sms_bodies';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsFeedbackWord.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsFeedbackWord.php
@@ -4,6 +4,6 @@ namespace Inensus\SteamaMeter\Models;
 
 use App\Models\Base\BaseModel;
 
-class SteamaSmsFeedbackWord extends \App\Models\Base\BaseModel {
+class SteamaSmsFeedbackWord extends BaseModel {
     protected $table = 'steama_sms_feedback_words';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsNotifiedCustomer.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsNotifiedCustomer.php
@@ -2,9 +2,10 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class SteamaSmsNotifiedCustomer extends \App\Models\Base\BaseModel {
+class SteamaSmsNotifiedCustomer extends BaseModel {
     protected $table = 'steama_sms_notified_customers';
 
     public function notify(): MorphTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsSetting.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsSetting.php
@@ -4,7 +4,7 @@ namespace Inensus\SteamaMeter\Models;
 
 use App\Models\Base\BaseModel;
 
-class SteamaSmsSetting extends \App\Models\Base\BaseModel {
+class SteamaSmsSetting extends BaseModel {
     protected $table = 'steama_sms_settings';
 
     public function setting() {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsVariableDefaultValue.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSmsVariableDefaultValue.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaSmsVariableDefaultValue extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaSmsVariableDefaultValue extends BaseModel {
     protected $table = 'steama_sms_variable_default_values';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSubscriptionPaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSubscriptionPaymentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaSubscriptionPaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaSubscriptionPaymentPlan extends BaseModel {
     protected $table = 'steama_subscription_payment_plans';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSyncAction.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSyncAction.php
@@ -2,7 +2,9 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaSyncAction extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaSyncAction extends BaseModel {
     protected $table = 'steama_sync_actions';
 
     public function synSetting() {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaSyncSetting.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaSyncSetting.php
@@ -2,7 +2,9 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaSyncSetting extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaSyncSetting extends BaseModel {
     protected $table = 'steama_sync_settings';
 
     public function syncAction() {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaTariff.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaTariff.php
@@ -2,10 +2,11 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Meter\MeterTariff;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class SteamaTariff extends \App\Models\Base\BaseModel {
+class SteamaTariff extends BaseModel {
     protected $table = 'steama_tariffs';
 
     public function mpmTariff(): BelongsTo {

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaTariffOverridePaymentPlan.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaTariffOverridePaymentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Inensus\SteamaMeter\Models;
 
-class SteamaTariffOverridePaymentPlan extends \App\Models\Base\BaseModel {
+use App\Models\Base\BaseModel;
+
+class SteamaTariffOverridePaymentPlan extends BaseModel {
     protected $table = 'steama_tariff_override_payment_plans';
 }

--- a/src/backend/packages/inensus/steama-meter/src/Models/SteamaUserType.php
+++ b/src/backend/packages/inensus/steama-meter/src/Models/SteamaUserType.php
@@ -2,13 +2,14 @@
 
 namespace Inensus\SteamaMeter\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\ConnectionType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property ConnectionType $mpmConnectionType
  */
-class SteamaUserType extends \App\Models\Base\BaseModel {
+class SteamaUserType extends BaseModel {
     protected $table = 'steama_user_types';
 
     public function mpmConnectionType(): BelongsTo {

--- a/src/backend/packages/inensus/ticket/src/Models/Ticket.php
+++ b/src/backend/packages/inensus/ticket/src/Models/Ticket.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\Ticket\Models;
 
+use App\Models\Base\BaseModel;
 use App\Models\Person\Person;
 use Carbon\Carbon;
 use Database\Factories\Inensus\Ticket\Models\TicketFactory;
@@ -33,7 +34,7 @@ use Illuminate\Support\Facades\DB;
  * @property TicketCategory  $category
  * @property ?Person         $owner
  */
-class Ticket extends \App\Models\Base\BaseModel {
+class Ticket extends BaseModel {
     /** @use HasFactory<TicketFactory> */
     use HasFactory;
 

--- a/src/backend/packages/inensus/ticket/src/Models/TicketCategory.php
+++ b/src/backend/packages/inensus/ticket/src/Models/TicketCategory.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\Ticket\Models;
 
+use App\Models\Base\BaseModel;
 use Database\Factories\Inensus\Ticket\Models\TicketFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * @property string $label_color
  * @property int    $out_source
  */
-class TicketCategory extends \App\Models\Base\BaseModel {
+class TicketCategory extends BaseModel {
     /** @use HasFactory<TicketFactory> */
     use HasFactory;
 

--- a/src/backend/packages/inensus/ticket/src/Models/TicketComment.php
+++ b/src/backend/packages/inensus/ticket/src/Models/TicketComment.php
@@ -2,9 +2,10 @@
 
 namespace Inensus\Ticket\Models;
 
+use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class TicketComment extends \App\Models\Base\BaseModel {
+class TicketComment extends BaseModel {
     protected $table = 'ticket_comments';
 
     /**

--- a/src/backend/packages/inensus/ticket/src/Models/TicketOutsource.php
+++ b/src/backend/packages/inensus/ticket/src/Models/TicketOutsource.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\Ticket\Models;
 
+use App\Models\Base\BaseModel;
 use Carbon\Carbon;
 use Database\Factories\Inensus\Ticket\Models\TicketOutsourceFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -14,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property Carbon $created_at
  * @property Carbon $updated_at
  */
-class TicketOutsource extends \App\Models\Base\BaseModel {
+class TicketOutsource extends BaseModel {
     /** @use HasFactory<TicketOutsourceFactory> */
     use HasFactory;
 

--- a/src/backend/packages/inensus/ticket/src/Models/TicketOutsourceReport.php
+++ b/src/backend/packages/inensus/ticket/src/Models/TicketOutsourceReport.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\Ticket\Models;
 
+use App\Models\Base\BaseModel;
 use Database\Factories\Inensus\Ticket\Models\TicketOutsourceReportFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -12,7 +13,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * @property string $date
  * @property string $path
  */
-class TicketOutsourceReport extends \App\Models\Base\BaseModel {
+class TicketOutsourceReport extends BaseModel {
     /** @use HasFactory<TicketOutsourceReportFactory> */
     use HasFactory;
 

--- a/src/backend/packages/inensus/ticket/src/Models/TicketUser.php
+++ b/src/backend/packages/inensus/ticket/src/Models/TicketUser.php
@@ -2,6 +2,7 @@
 
 namespace Inensus\Ticket\Models;
 
+use App\Models\Base\BaseModel;
 use Carbon\Carbon;
 use Database\Factories\Inensus\Ticket\Models\TicketUserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -16,7 +17,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
  * @property Carbon $created_at
  * @property Carbon $updated_at
  */
-class TicketUser extends \App\Models\Base\BaseModel {
+class TicketUser extends BaseModel {
     /** @use HasFactory<TicketUserFactory> */
     use HasFactory;
 


### PR DESCRIPTION
Closes: #992 

### Brief summary of the change made

This PR deprecates redundant `BaseModel.php` files in packages like `ticket`, `spark-meter`, `steama-meter`, `bulk-registration`, and `mesomb-payment-provider`. All affected models now extend the shared `BaseModel` from the root `BaseModel.php`, eliminating duplication. The root `BaseModel` was updated to include the `resolveChildRouteBinding` method for compatibility. This centralizes the base model, reducing maintenance overhead and potential inconsistencies across the codebase.

### Are there any other side effects of this change that we should be aware of?
None as of now.

### Describe how you tested your changes?
Testing was conducted in the dev container (Ubuntu 24.04.2 LTS). Syntax checks (php -l) passed on the root `BaseModel` and sample migrated models (e.g., `Ticket.php`). File integrity was verified: redundant `BaseModel.php` files were deleted, and all extends were updated. Prettier ran successfully on frontend code. Full composer install failed due to PHP version mismatch (8.0 vs. required 8.2+), but targeted validation confirmed no breaking changes. Recommend running php artisan test in a compatible environment for end-to-end validation

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [x] Changes tested as described above
- [x] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.
