### PR TITLE
Create PROXY ONLY subnet once per project

### DIFF
--- a/terraform/gcp_kubernetes/main.tf
+++ b/terraform/gcp_kubernetes/main.tf
@@ -135,8 +135,8 @@ resource "google_compute_firewall" "allow_proxy_connection" {
 }
 
 moved {
-    from = google_compute_firewall.rules
-    to = google_compute_firewall.allow_proxy_connection
+  from = google_compute_firewall.rules
+  to   = google_compute_firewall.allow_proxy_connection
 }
 
 # Static IP address to be used in Kubernetes **Internal** Ingress in a scenario

--- a/terraform/gcp_kubernetes/variables.tf
+++ b/terraform/gcp_kubernetes/variables.tf
@@ -72,8 +72,8 @@ When configure_gcp_project is set, this CIDR range will be used to create the pr
 Otherwise the proxy only subnet with the provided ranges is assumed to be existent.
 EOT
   type        = string
-  # Avoiding: https://cloud.google.com/vpc/docs/subnets#additional-ipv4-considerations
   default     = "172.16.0.0/23"
+  # Avoiding: https://cloud.google.com/vpc/docs/subnets#additional-ipv4-considerations
 
   validation {
     condition = (


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

PROXY ONLY subnet should be unique per project. Updating our Terraform module to account for that, in scenarios where multiple environments are managed in the same GCP project.

To achieve this, we are introducing a new variable `network_proxy_only_subnet_cidr_range`. When the proxy only subnet is managed (created) this CIDR range will be used, else is assumed to be existing.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
