### PR TITLE
Fix Maintenance user selection

### DIFF
--- a/docs/usage-guide/maintenance.md
+++ b/docs/usage-guide/maintenance.md
@@ -7,7 +7,7 @@ order: 13
 As outlined in the [Terminology](terminology), "Maintenance Service Providers" are usually persons that are not hired on a fixed-term by the company but are available on-demand near the site to respond to technical faults.
 
 Such technical issues are related to a system as a whole (for instance, a mini-grid), rather than being customer-specific.
-To **generate maintenance requests**, go to the "Maintenance " menu on the website interface (see below).
+To **generate maintenance requests**, go to the "Maintenance" menu on the website interface (see below).
 If the maintenance service provider to which the user wants to assign the maintenance request is already registered on the MicroPowerManager account, simply create the request (state the task to be done, the deadline and the price to be paid to the maintenance service provider) and assign it to the corresponding maintenance service provider.
 If the maintenance service provider is still to be registered, click first on ":heavy_plus_sign:" to register a new maintenance provider.
 Then you can proceed to create a new "Maintenance request".

--- a/src/frontend/src/ExportedRoutes.js
+++ b/src/frontend/src/ExportedRoutes.js
@@ -31,6 +31,7 @@ import TransactionList from "./pages/Transaction/index.vue"
 import TransactionSearch from "./pages/Transaction/index.vue"
 import TransactionDetail from "./pages/Transaction/_id.vue"
 import TicketList from "./pages/Ticket/index.vue"
+import TicketSettingsCategories from "./pages/Ticket/Setting/Category/index.vue"
 import TariffList from "./pages/Tariff/index.vue"
 import TariffDetail from "./pages/Tariff/_id.vue"
 import MeterList from "./pages/Meter/index.vue"
@@ -531,6 +532,17 @@ export const exportedRoutes = [
           sidebar: {
             enabled: true,
             name: "List",
+          },
+        },
+      },
+      {
+        path: "tickets-settings/categories",
+        component: TicketSettingsCategories,
+        meta: {
+          layout: "default",
+          sidebar: {
+            enabled: true,
+            name: "Categories",
           },
         },
       },

--- a/src/frontend/src/modules/Maintenance/Maintenance.vue
+++ b/src/frontend/src/modules/Maintenance/Maintenance.vue
@@ -61,16 +61,14 @@
                     <md-option value="" disabled selected>
                       -- {{ $tc("words.select") }} --
                     </md-option>
-                    <template v-for="employee in employees">
-                      <md-option
-                        :key="employee.id"
-                        v-if="employee.person"
-                        :value="employee.id"
-                      >
-                        {{ employee.person.name }}
-                        {{ employee.person.surname }}
-                      </md-option>
-                    </template>
+                    <md-option
+                      v-for="employee in employees"
+                      :key="employee.id"
+                      :value="employee.id"
+                    >
+                      {{ employee.name }}
+                      {{ employee.surname }}
+                    </md-option>
                   </md-select>
                   <span class="md-error">
                     {{ errors.first($tc("words.employee")) }}


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Currently, on the Demo Maintenance Requests cannot be assigned to maintenance users
<img width="851" height="301" alt="image" src="https://github.com/user-attachments/assets/04aeb25c-fc7a-429b-b271-d5e008e47476" />

This PR fixes it

<img width="487" height="481" alt="image" src="https://github.com/user-attachments/assets/2fa391b6-4b52-4089-a235-39d8c035a45a" />

Also, bringing back the Maintenance Category Page.


### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
