### PR TITLE
Include `tenant_id` in Reports file storage

### DIFF
--- a/src/backend/app/Http/Controllers/Reports.php
+++ b/src/backend/app/Http/Controllers/Reports.php
@@ -572,8 +572,12 @@ class Reports {
         }
 
         try {
+            $user = User::query()->first();
+            $databaseProxy = app(DatabaseProxy::class);
+            $companyId = $databaseProxy->findByEmail($user->email)->getCompanyId();
+
             $fileName = Str::slug("{$reportType}-{$cityName}-{$dateRange}").'.xlsx';
-            $path = "reports/village_report_{$reportType}/{$fileName}";
+            $path = "reports/{$companyId}/village_report_{$reportType}/{$fileName}";
 
             // Save to a temporary local file
             $tempFile = tempnam(sys_get_temp_dir(), 'city_report_').'.xlsx';
@@ -582,10 +586,6 @@ class Reports {
 
             Storage::put($path, file_get_contents($tempFile));
             unlink($tempFile);
-
-            $user = User::query()->first();
-            $databaseProxy = app(DatabaseProxy::class);
-            $companyId = $databaseProxy->findByEmail($user->email)->getCompanyId();
 
             // Save report metadata
             $this->report->create([

--- a/src/backend/app/Services/AbstractExportService.php
+++ b/src/backend/app/Services/AbstractExportService.php
@@ -6,6 +6,8 @@ use App\Exceptions\ActiveSheetNotCreatedException;
 use App\Exceptions\Export\CsvNotSavedException;
 use App\Exceptions\Export\SpreadSheetNotCreatedException;
 use App\Exceptions\Export\SpreadSheetNotSavedException;
+use App\Models\DatabaseProxy;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
@@ -101,7 +103,11 @@ abstract class AbstractExportService {
 
     public function saveSpreadSheet(): string {
         try {
-            $directory = 'export';
+            $user = User::query()->first();
+            $databaseProxy = app(DatabaseProxy::class);
+            $companyId = $databaseProxy->findByEmail($user->email)->getCompanyId();
+
+            $directory = "export/{$companyId}";
             $fileName = $this->getPrefix().'-'.now()->format('Ymd_His_u').'.xlsx';
             $path = "{$directory}/{$fileName}";
 
@@ -124,7 +130,11 @@ abstract class AbstractExportService {
      */
     public function saveCsv(array $headers = []): string {
         try {
-            $directory = 'export';
+            $user = User::query()->first();
+            $databaseProxy = app(DatabaseProxy::class);
+            $companyId = $databaseProxy->findByEmail($user->email)->getCompanyId();
+
+            $directory = "export/{$companyId}";
             $fileName = $this->getPrefix().'-'.now()->format('Ymd_His_u').'.csv';
             $path = "{$directory}/{$fileName}";
 


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This PR is an improvement suggestion to the way we store files in folder structure (applies to both temporary local storage and persisted cloud storage).

Currently, all files from all tenants are stored in the same directories. 

- This might be harder to work with, as it's not immediately clear which files belong to which tenant from the files alone.

- Theoretically, there is also the chance of duplicated filenames between different tenants. Although we consider this highly unlikely and it's not the motivation for this PR.

The suggestion here is to simply include the tenant id in as a subfolder. 

<img width="240" height="145" alt="image" src="https://github.com/user-attachments/assets/130a20d5-f784-430c-95c0-8940c621c8a4" />

Happy to hear thoughts on that approach.


### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
