### PR TITLE
Remove unused Prospect API configuration variables

### DIFF
--- a/src/backend/config/services.php
+++ b/src/backend/config/services.php
@@ -44,8 +44,4 @@ return [
     'waveMoney' => [
         'url' => env('WAVEMONEY_API_URL'),
     ],
-    'prospect' => [
-        'default_api_url' => env('PROSPECT_API_URL', 'https://demo.prospect.energy/api/v1/in/'),
-        'api_token' => env('PROSPECT_API_TOKEN'),
-    ],
 ];

--- a/src/backend/packages/inensus/prospect/src/Services/ProspectCredentialService.php
+++ b/src/backend/packages/inensus/prospect/src/Services/ProspectCredentialService.php
@@ -17,7 +17,7 @@ class ProspectCredentialService {
      */
     public function createCredentials(): ProspectCredential {
         return $this->credential->newQuery()->firstOrCreate(['id' => 1], [
-            'api_url' => config('services.prospect.default_api_url').'installations',
+            'api_url' => null,
             'api_token' => null,
         ]);
     }


### PR DESCRIPTION
This PR removes `PROSPECT_API_URL` and `PROSPECT_API_TOKEN` from `services.php` as these values are now retrieved from the `prospect_credentials` table. This cleanup simplifies configuration and prevents redundant environment variables.

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
