### PR TITLE
Fix Service account name in TF

### DIFF
--- a/terraform/gcp_kubernetes/main.tf
+++ b/terraform/gcp_kubernetes/main.tf
@@ -268,8 +268,8 @@ resource "google_storage_bucket" "mpm-backend-storage" {
 
 resource "google_service_account" "mpm_service_account" {
   account_id   = local.service_account_name
-  display_name = "MPM ${var.resoure_suffix} Storage Environment Account"
-  description  = "Service account for ${var.resoure_suffix}  environment"
+  display_name = "MPM Service Account - ${title(replace(var.resoure_suffix, "-", ""))}"
+  description  = "Service account for ${title(replace(var.resoure_suffix, "-", ""))} environment"
 }
 
 resource "google_storage_bucket_iam_member" "mpm_storage_permission" {
@@ -278,7 +278,6 @@ resource "google_storage_bucket_iam_member" "mpm_storage_permission" {
   member = "serviceAccount:${google_service_account.mpm_service_account.email}"
 }
 
-# 
 #
 # Redis
 #


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Fixes

```
      ~ description  = "Service account for Demo environment" -> "Service account for -demo  environment"
      ~ display_name = "MPM Demo Environment Service Account" -> "MPM -demo Storage Environment Account"
```

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
