### PR TITLE
Fix `status`'s ternary logic in Transaction Export

### DIFF
--- a/collections/Export/Export Transactions Data CSV.bru
+++ b/collections/Export/Export Transactions Data CSV.bru
@@ -5,17 +5,17 @@ meta {
 }
 
 get {
-  url: {{mpm_backend_url}}/api/export/transactions?format=csv&deviceType=all
+  url: {{mpm_backend_url}}/api/export/transactions?format=csv&deviceType=solar_home_system
   body: multipartForm
   auth: inherit
 }
 
 params:query {
   format: csv
-  deviceType: all
-  ~status: 0
+  deviceType: solar_home_system
+  ~status: 1
+  ~provider: wave_money_transaction
   ~serial_number: 4f3a0cdc-7728-31d7-98f9-aaa25f00b2f0
   ~currency: TZS
   ~timeZone: UTC
-  ~provider: agent_transaction
 }

--- a/src/backend/app/Http/Controllers/TransactionExportController.php
+++ b/src/backend/app/Http/Controllers/TransactionExportController.php
@@ -44,7 +44,7 @@ class TransactionExportController {
             $serialNumber,
             $tariffId,
             $transactionProvider,
-            (int) $status,
+            is_null($status) ? null : (int) $status,
             $fromDate,
             $toDate,
         );
@@ -73,7 +73,7 @@ class TransactionExportController {
             null,
             null,
             $transactionProvider,
-            (int) $status,
+            is_null($status) ? null : (int) $status,
             $fromDate,
             $toDate,
         );


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

`$status` is essentially ternary (three-valued):

- `null` => export all
- `0` => pending transactions
- `1` => succesful transactions

As we are passing `(int) $status` to the service, which converts `null` to 0. The all export would only export pending transactions (which is empty on demo).

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
