### PR TITLE
Accept Point GeoJSON OSM search data

### DIFF
--- a/src/frontend/src/services/MappingService.js
+++ b/src/frontend/src/services/MappingService.js
@@ -62,10 +62,12 @@ export class MappingService {
       const { data, error, status } = await this.repository.get(name)
       if (status !== 200) return new ErrorHandler(error, "http", status)
 
-      // Filter GeoJSON features by type
-      const features = data.features || []
+      const normalizedFeatures = (data.features || [])
+        .map((f) => this.normalizeFeatureGeometry(f))
+        .filter(Boolean)
+
       const filteredFeatures = this.filterGeoJSONFeatures(
-        features,
+        normalizedFeatures,
         filteredTypes,
       )
 
@@ -93,6 +95,42 @@ export class MappingService {
       const geoType = feature.geometry?.type?.toLowerCase()
       return geoType && geoType in filteredTypes
     })
+  }
+
+  /**
+   * Converts non-polygon geometries (Point, LineString) into a Polygon
+   * derived from the feature's bounding box. This ensures downstream code
+   * that expects a polygon geometry always receives one.
+   */
+  normalizeFeatureGeometry(feature) {
+    const polygonTypes = ["Polygon", "MultiPolygon"]
+    if (polygonTypes.includes(feature.geometry?.type)) {
+      return feature
+    }
+
+    // Fall back to bbox → bounding rectangle polygon
+    const bbox = feature.bbox
+    if (!bbox || bbox.length < 4) {
+      console.warn("Feature has no usable geometry or bbox, skipping:", feature)
+      return null
+    }
+
+    const [minLon, minLat, maxLon, maxLat] = bbox
+    return {
+      ...feature,
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [minLon, minLat],
+            [maxLon, minLat],
+            [maxLon, maxLat],
+            [minLon, maxLat],
+            [minLon, minLat],
+          ],
+        ],
+      },
+    }
   }
 
   strToHex(str) {

--- a/src/frontend/src/shared/MapWithDrawer.vue
+++ b/src/frontend/src/shared/MapWithDrawer.vue
@@ -235,9 +235,12 @@ export default {
             this.initMap()
           }
 
-          const filteredFeatures = this.filterGeoJSONFeatures(
-            response.data.features || [],
-          )
+          const normalizedFeatures = (response.data.features || [])
+            .map((f) => this.normalizeFeatureGeometry(f))
+            .filter(Boolean)
+
+          const filteredFeatures =
+            this.filterGeoJSONFeatures(normalizedFeatures)
 
           this.geoData = filteredFeatures.map((feature) => ({
             feature: feature,
@@ -249,6 +252,44 @@ export default {
 
           this.setGeoLocation(filteredFeatures)
         })
+    },
+    /**
+     * Converts non-polygon geometries (Point, LineString) into a Polygon
+     * derived from the feature's bounding box. This ensures downstream code
+     * that expects a polygon geometry always receives one.
+     */
+    normalizeFeatureGeometry(feature) {
+      const polygonTypes = ["Polygon", "MultiPolygon"]
+      if (polygonTypes.includes(feature.geometry?.type)) {
+        return feature
+      }
+
+      // Fall back to bbox → bounding rectangle polygon
+      const bbox = feature.bbox
+      if (!bbox || bbox.length < 4) {
+        console.warn(
+          "Feature has no usable geometry or bbox, skipping:",
+          feature,
+        )
+        return null
+      }
+
+      const [minLon, minLat, maxLon, maxLat] = bbox
+      return {
+        ...feature,
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [minLon, minLat],
+              [maxLon, minLat],
+              [maxLon, maxLat],
+              [minLon, maxLat],
+              [minLon, minLat],
+            ],
+          ],
+        },
+      }
     },
 
     filterGeoJSONFeatures(features) {


### PR DESCRIPTION
Closes #1319 

This PR attempts to normalize Point (GeoJSON type) search responses from OSM into the acceptable Polygon type. The boundary created isn't well defined like an actual Polygon but it is a fair trade-off instead of doing nothing. 


<img width="1572" height="1168" alt="Screenshot 2026-02-23 at 9 41 51 AM" src="https://github.com/user-attachments/assets/3860f6e9-1ec0-48b5-82fa-bc2e0dc3aa16" />


<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
