### PR TITLE
fix: prevent duplicate customer addresses when selling appliances

### DIFF
--- a/src/backend/app/Http/Controllers/AppliancePersonController.php
+++ b/src/backend/app/Http/Controllers/AppliancePersonController.php
@@ -8,12 +8,11 @@ use App\Http\Resources\ApiResource;
 use App\Models\Appliance;
 use App\Models\AppliancePerson;
 use App\Models\Person\Person;
-use App\Services\AddressesService;
-use App\Services\AddressGeographicalInformationService;
 use App\Services\AppliancePersonService;
 use App\Services\ApplianceRateService;
 use App\Services\ApplianceService;
 use App\Services\CashTransactionService;
+use App\Services\DeviceGeographicalInformationService;
 use App\Services\DeviceService;
 use App\Services\GeographicalInformationService;
 use App\Services\UserAppliancePersonService;
@@ -28,9 +27,8 @@ class AppliancePersonController extends Controller {
         private UserAppliancePersonService $userAppliancePersonService,
         private UserService $userService,
         private DeviceService $deviceService,
-        private AddressesService $addressesService,
         private GeographicalInformationService $geographicalInformationService,
-        private AddressGeographicalInformationService $addressGeographicalInformationService,
+        private DeviceGeographicalInformationService $deviceGeographicalInformationService,
         private CashTransactionService $cashTransactionService,
         private ApplianceService $applianceService,
         private ApplianceRateService $applianceRateService,
@@ -79,27 +77,33 @@ class AppliancePersonController extends Controller {
 
             if ($deviceSerial) {
                 $device = $this->deviceService->getBySerialNumber($deviceSerial);
+                if (!$device) {
+                    throw new \Exception('Selected device could not be found.');
+                }
                 $this->deviceService->update($device, ['person_id' => $personId]);
                 $appliancePerson->device_serial = $deviceSerial;
 
-                $address = $this->addressesService->make([
-                    'street' => $addressData['street'],
-                    'city_id' => $addressData['city_id'],
-                ]);
+                if (!empty($points)) {
+                    $device->refresh();
+                    $existingGeo = $device->geo;
 
-                // Attach the new address to the person rather than the device.
-                $this->addressesService->assignAddressToOwner($appliancePerson->person, $address);
-
-                $geographicalInformation = $this->geographicalInformationService->make([
-                    'points' => $points,
-                ]);
-                $this->addressGeographicalInformationService->setAssigned($geographicalInformation);
-                $this->addressGeographicalInformationService->setAssignee($address);
-                $this->addressGeographicalInformationService->assign();
-                $this->geographicalInformationService->save($geographicalInformation);
+                    if ($existingGeo) {
+                        $this->geographicalInformationService->update($existingGeo, [
+                            'points' => $points,
+                        ]);
+                    } else {
+                        $geographicalInformation = $this->geographicalInformationService->make([
+                            'points' => $points,
+                        ]);
+                        $this->deviceGeographicalInformationService->setAssigned($geographicalInformation);
+                        $this->deviceGeographicalInformationService->setAssignee($device);
+                        $this->deviceGeographicalInformationService->assign();
+                        $this->geographicalInformationService->save($geographicalInformation);
+                    }
+                }
             }
             if ($downPayment > 0) {
-                $sender = isset($addressData) ? $addressData['phone'] : '-';
+                $sender = $addressData['phone'] ?? '-';
                 $transaction = $this->cashTransactionService->createCashTransaction(
                     $user->id,
                     $downPayment,

--- a/src/backend/app/Services/AgentSoldApplianceService.php
+++ b/src/backend/app/Services/AgentSoldApplianceService.php
@@ -16,8 +16,6 @@ use Illuminate\Pagination\LengthAwarePaginator;
  */
 class AgentSoldApplianceService implements IBaseService {
     public function __construct(
-        private AddressesService $addressesService,
-        private AddressGeographicalInformationService $addressGeographicalInformationService,
         private AgentAppliancePersonService $agentAppliancePersonService,
         private AgentAssignedApplianceHistoryBalanceService $agentAssignedApplianceHistoryBalanceService,
         private AgentAssignedApplianceService $agentAssignedApplianceService,
@@ -31,6 +29,7 @@ class AgentSoldApplianceService implements IBaseService {
         private AppliancePersonService $appliancePersonService,
         private ApplianceRateService $applianceRateService,
         private AppliancePerson $appliancePerson,
+        private DeviceGeographicalInformationService $deviceGeographicalInformationService,
         private DeviceService $deviceService,
         private GeographicalInformationService $geographicalInformationService,
         private PersonService $personService,
@@ -192,32 +191,35 @@ class AgentSoldApplianceService implements IBaseService {
         $this->appliancePersonService->save($appliancePerson);
 
         if ($deviceSerial) {
-            $addressFromCustomer = $appliancePerson->person()->first()->addresses()->first();
-            $addressData = $requestData['address'] ?? [
-                'street' => $addressFromCustomer->street,
-                'city_id' => $addressFromCustomer->city_id,
-            ];
-            $points = $requestData['points'] ?? $addressFromCustomer->geo()->first()->points;
+            $person = $appliancePerson->person()->with('addresses.geo')->first();
+            $primaryAddress = $person?->addresses()->where('is_primary', 1)->first();
+            $points = $requestData['points'] ?? $primaryAddress?->geo?->points;
 
             $device = $this->deviceService->getBySerialNumber($deviceSerial);
+            if (!$device) {
+                throw new \Exception('Selected device could not be found.');
+            }
             $this->deviceService->update($device, ['person_id' => $requestData['person_id']]);
 
-            $address = $this->addressesService->make([
-                'street' => $addressData['street'],
-                'city_id' => $addressData['city_id'],
-            ]);
+            if (!empty($points)) {
+                $device->refresh();
+                $existingGeo = $device->geo;
 
-            // Attach the new address to the buyer (person) rather than the device.
-            $this->addressesService->assignAddressToOwner($appliancePerson->person, $address);
+                if ($existingGeo) {
+                    $this->geographicalInformationService->update($existingGeo, [
+                        'points' => $points,
+                    ]);
+                } else {
+                    $geoInfo = $this->geographicalInformationService->make([
+                        'points' => $points,
+                    ]);
 
-            $geoInfo = $this->geographicalInformationService->make([
-                'points' => $points,
-            ]);
-
-            $this->addressGeographicalInformationService->setAssigned($geoInfo);
-            $this->addressGeographicalInformationService->setAssignee($address);
-            $this->addressGeographicalInformationService->assign();
-            $this->geographicalInformationService->save($geoInfo);
+                    $this->deviceGeographicalInformationService->setAssigned($geoInfo);
+                    $this->deviceGeographicalInformationService->setAssignee($device);
+                    $this->deviceGeographicalInformationService->assign();
+                    $this->geographicalInformationService->save($geoInfo);
+                }
+            }
         }
 
         // initalize appliance Rates


### PR DESCRIPTION
## Summary
This PR fixes issue #1367 where selling an appliance to an existing customer via UI could create an additional non-primary customer address.

Closes #1367.

## Root Cause
During appliance sale flows, backend logic was creating and assigning a new  record to the customer when a device serial was provided. The sale operation should only bind the sold device and update device geolocation, not mutate customer address records.

The same pattern existed in both:
- web appliance sale flow ()
- agent appliance sale flow ()

## What Was Changed
### 1. 
- Removed customer-address creation/assignment from the sale path.
- Replaced address-geo association with device-geo association.
- Added safe handling for missing selected device (explicit exception).
- Updated geolocation update logic to:
  - update existing device geo when present
  - create and attach geo to device when missing
- Kept down payment sender fallback safe via null-coalescing.

### 2. 
- Removed address creation/assignment from agent sale processing.
- Stopped deriving new address payload during sale.
- Reused customer primary address geo only as a fallback source for points.
- Applied the same device-geo update/create logic as web flow.
- Added explicit guard for missing selected device.

## Expected Behavior After Fix
Selling an appliance to an existing customer no longer inserts extra customer address rows. Customer address data remains unchanged; only device ownership and device geolocation are updated by sale operations.

## Validation
Performed local syntax/error checks on modified backend files:
- No syntax errors detected in src/backend/app/Http/Controllers/AppliancePersonController.php
- No syntax errors detected in src/backend/app/Services/AgentSoldApplianceService.php
- editor diagnostics: no errors in modified backend files.

## Notes
This PR is intentionally scoped to the backend sale logic required for #1367 and does not include unrelated local workspace changes.