### PR TITLE
feat: add village overview and detail editing

### DIFF
--- a/src/frontend/src/ExportedRoutes.js
+++ b/src/frontend/src/ExportedRoutes.js
@@ -48,6 +48,8 @@ import TransactionDetail from "@/modules/Transactions/Transaction.vue"
 import TransactionList from "@/modules/Transactions/Transactions.vue"
 import UnauthorizedPage from "@/modules/Unauthorized/index.vue"
 import AddVillage from "@/modules/Village/AddVillage.vue"
+import VillageDetail from "@/modules/Village/VillageDetail.vue"
+import VillageList from "@/modules/Village/Villages.vue"
 import Welcome from "@/modules/Welcome/index.vue"
 import AfricasTalkingOverview from "@/plugins/africas-talking/modules/Overview/Overview.vue"
 import AngazaShsOverview from "@/plugins/angaza-shs/modules/Overview/Overview.vue"
@@ -451,6 +453,45 @@ export const exportedRoutes = [
             level: "detail",
             name: "Customers",
             link: "/people",
+            target: "id",
+          },
+        },
+      },
+    ],
+  },
+  {
+    path: "/villages",
+    component: ChildRouteWrapper,
+    meta: {
+      permissions: ["settings"],
+      sidebar: {
+        enabled: true,
+        name: "Villages",
+        icon: "location_city",
+      },
+    },
+    children: [
+      {
+        path: "",
+        component: VillageList,
+        meta: {
+          layout: "default",
+          breadcrumb: {
+            level: "base",
+            name: "Villages",
+            link: "/villages",
+          },
+        },
+      },
+      {
+        path: ":id",
+        component: VillageDetail,
+        meta: {
+          layout: "default",
+          breadcrumb: {
+            level: "detail",
+            name: "Villages",
+            link: "/villages",
             target: "id",
           },
         },

--- a/src/frontend/src/assets/locales/ar.json
+++ b/src/frontend/src/assets/locales/ar.json
@@ -40,6 +40,7 @@
     "Tariffs": "التعريفات",
     "Tickets": "التذاكر",
     "Transactions": "المعاملات",
+    "Villages": "القرى",
     "Viber Messaging": "مراسلة فايبر",
     "WaveMoney": "ويف موني",
     "Wavecom Payment Provider": "مزود الدفع ويفكوم",

--- a/src/frontend/src/assets/locales/bu.json
+++ b/src/frontend/src/assets/locales/bu.json
@@ -40,6 +40,7 @@
     "Tariffs": "Jှ+နး်ထားများ",
     "Tickets": "ကွနပ်လိနး်များ",
     "Transactions": "ေငေွပးေငယွ ူ",
+    "Villages": "ေကျးရွာများ",
     "Viber Messaging": "Viber Messaging",
     "WaveMoney": "Wave Money",
     "Wavecom Payment Provider": "Wavecom Payment Provider",

--- a/src/frontend/src/assets/locales/en.json
+++ b/src/frontend/src/assets/locales/en.json
@@ -40,6 +40,7 @@
     "Tariffs": "Tariffs",
     "Tickets": "Tickets",
     "Transactions": "Transactions",
+    "Villages": "Villages",
     "Viber Messaging": "Viber Messaging",
     "WaveMoney": "Wave Money",
     "Wavecom Payment Provider": "Wavecom Payment Provider",

--- a/src/frontend/src/assets/locales/fr.json
+++ b/src/frontend/src/assets/locales/fr.json
@@ -40,6 +40,7 @@
     "Tariffs": "Tariffs",
     "Tickets": "Tickets",
     "Transactions": "Transactions",
+    "Villages": "Villages",
     "Viber Messaging": "Viber Messaging",
     "WaveMoney": "Wave Money",
     "Wavecom Payment Provider": "Wavecom Payment Provider",

--- a/src/frontend/src/modules/Village/VillageDetail.vue
+++ b/src/frontend/src/modules/Village/VillageDetail.vue
@@ -1,0 +1,229 @@
+<template>
+  <div>
+    <widget
+      :id="'village-detail'"
+      :title="village.name ? `${$tc('words.village')} - ${village.name}` : $tc('words.village')"
+      :subscriber="subscriber"
+      color="primary"
+    >
+      <md-card>
+        <md-card-content>
+          <form class="md-layout md-gutter" data-vv-scope="village-detail-form">
+            <div class="md-layout-item md-size-50 md-small-size-100">
+              <md-field
+                :class="{
+                  'md-invalid': errors.has('village-detail-form.name'),
+                }"
+              >
+                <label for="village_name">{{ $tc("words.name") }}</label>
+                <md-input
+                  id="village_name"
+                  name="name"
+                  v-model="village.name"
+                  :disabled="!$can('settings')"
+                  v-validate="'required|min:2'"
+                />
+                <span class="md-error">
+                  {{ errors.first("village-detail-form.name") }}
+                </span>
+              </md-field>
+            </div>
+
+            <div class="md-layout-item md-size-50 md-small-size-100">
+              <md-field
+                :class="{
+                  'md-invalid': errors.has('village-detail-form.country'),
+                }"
+              >
+                <label for="country_id">{{ $tc("words.country") }}</label>
+                <md-select
+                  id="country_id"
+                  name="country"
+                  v-model="village.countryId"
+                  :disabled="!$can('settings')"
+                  v-validate="'required'"
+                >
+                  <md-option
+                    v-for="country in countryService.list"
+                    :key="country.id"
+                    :value="country.id"
+                  >
+                    {{ country.name || country.country_name }}
+                  </md-option>
+                </md-select>
+                <span class="md-error">
+                  {{ errors.first("village-detail-form.country") }}
+                </span>
+              </md-field>
+            </div>
+
+            <div class="md-layout-item md-size-50 md-small-size-100">
+              <md-field
+                :class="{
+                  'md-invalid': errors.has('village-detail-form.mini_grid'),
+                }"
+              >
+                <label for="mini_grid_id">{{ $tc("words.miniGrid") }}</label>
+                <md-select
+                  id="mini_grid_id"
+                  name="mini_grid"
+                  v-model="village.miniGridId"
+                  :disabled="!$can('settings')"
+                  v-validate="'required'"
+                >
+                  <md-option
+                    v-for="miniGrid in miniGridService.list"
+                    :key="miniGrid.id"
+                    :value="miniGrid.id"
+                  >
+                    {{ miniGrid.name }}
+                  </md-option>
+                </md-select>
+                <span class="md-error">
+                  {{ errors.first("village-detail-form.mini_grid") }}
+                </span>
+              </md-field>
+            </div>
+
+            <div class="md-layout-item md-size-50 md-small-size-100">
+              <md-field>
+                <label for="village_location">{{ $tc("words.location") }}</label>
+                <md-input
+                  id="village_location"
+                  :value="village.points || '-'"
+                  disabled
+                />
+              </md-field>
+            </div>
+          </form>
+        </md-card-content>
+
+        <md-card-actions>
+          <md-button
+            v-if="$can('settings')"
+            class="md-raised md-primary"
+            :disabled="loading"
+            @click="saveVillage"
+          >
+            {{ $tc("words.save") }}
+          </md-button>
+          <md-button class="md-raised" :disabled="loading" @click="goBack">
+            {{ $tc("words.close") }}
+          </md-button>
+        </md-card-actions>
+      </md-card>
+    </widget>
+    <md-progress-bar md-mode="indeterminate" v-if="loading" />
+  </div>
+</template>
+
+<script>
+import { notify } from "@/mixins/notify.js"
+import { CityService } from "@/services/CityService.js"
+import CountryService from "@/services/CountryService.js"
+import { MiniGridService } from "@/services/MiniGridService.js"
+import { EventBus } from "@/shared/eventbus.js"
+import Widget from "@/shared/Widget.vue"
+
+export default {
+  name: "VillageDetail",
+  mixins: [notify],
+  components: { Widget },
+  data() {
+    return {
+      subscriber: "village-detail",
+      cityService: new CityService(),
+      miniGridService: new MiniGridService(),
+      countryService: new CountryService(),
+      villageId: this.$route.params.id,
+      loading: false,
+      village: {
+        id: null,
+        name: "",
+        countryId: null,
+        miniGridId: null,
+        points: "",
+      },
+    }
+  },
+  mounted() {
+    this.loadVillage()
+  },
+  methods: {
+    async loadVillage() {
+      this.loading = true
+      try {
+        await Promise.all([
+          this.miniGridService.getMiniGrids(),
+          this.countryService.getCountries(),
+        ])
+
+        const city = await this.cityService.getCity(this.villageId, true)
+        this.village = {
+          id: city.id,
+          name: city.name,
+          countryId: city.country_id,
+          miniGridId: city.mini_grid_id,
+          points: city.location?.points || "",
+        }
+
+        EventBus.$emit("widgetContentLoaded", this.subscriber, 1)
+      } catch (e) {
+        EventBus.$emit("widgetContentLoaded", this.subscriber, 0)
+        this.alertNotify("error", e.message)
+      }
+      this.loading = false
+    },
+    async saveVillage() {
+      const validator = await this.$validator.validateAll("village-detail-form")
+      if (!validator) {
+        return
+      }
+
+      this.loading = true
+      try {
+        const payload = {
+          name: this.village.name,
+          miniGridId: this.village.miniGridId,
+          countryId: this.village.countryId,
+          // Backend validation currently requires points on update.
+          points: this.village.points || "0,0",
+        }
+
+        const updatedVillage = await this.cityService.updateCity(
+          this.village.id,
+          payload,
+        )
+
+        this.village = {
+          ...this.village,
+          name: updatedVillage.name,
+          countryId: updatedVillage.country_id,
+          miniGridId: updatedVillage.mini_grid_id,
+        }
+
+        this.alertNotify(
+          "success",
+          this.$tc("messages.successfullyUpdated", 0, {
+            item: this.$tc("words.village"),
+          }),
+        )
+      } catch (e) {
+        this.alertNotify("error", e.message)
+      }
+      this.loading = false
+    },
+    goBack() {
+      this.$router.push("/villages")
+    },
+  },
+  watch: {
+    "$route.params.id": async function (newVillageId) {
+      this.villageId = newVillageId
+      await this.loadVillage()
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/frontend/src/modules/Village/Villages.vue
+++ b/src/frontend/src/modules/Village/Villages.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <widget
+      :id="'village-list'"
+      :title="'Villages'"
+      :subscriber="subscriber"
+      :button="true"
+      :button-text="$tc('menu.subMenu.addVillage')"
+      color="primary"
+      @widgetAction="goToAddVillage"
+    >
+      <md-table md-card style="margin-left: 0">
+        <md-table-row>
+          <md-table-head>{{ $tc("words.id") }}</md-table-head>
+          <md-table-head>{{ $tc("words.name") }}</md-table-head>
+          <md-table-head>{{ $tc("words.country") }}</md-table-head>
+          <md-table-head>{{ $tc("words.miniGrid") }}</md-table-head>
+          <md-table-head>{{ $tc("words.location") }}</md-table-head>
+          <md-table-head>{{ $tc("phrases.lastUpdate") }}</md-table-head>
+        </md-table-row>
+        <md-table-row
+          v-for="village in villages"
+          :key="village.id"
+          class="cursor-pointer"
+          @click="goToVillageDetail(village.id)"
+        >
+          <md-table-cell>{{ village.id }}</md-table-cell>
+          <md-table-cell>{{ village.name }}</md-table-cell>
+          <md-table-cell>{{ getCountryName(village.country_id) }}</md-table-cell>
+          <md-table-cell>{{ getMiniGridName(village.mini_grid_id) }}</md-table-cell>
+          <md-table-cell>{{ village.location?.points || "-" }}</md-table-cell>
+          <md-table-cell>{{ timeForTimeZone(village.updated_at) }}</md-table-cell>
+        </md-table-row>
+      </md-table>
+    </widget>
+  </div>
+</template>
+
+<script>
+import { notify } from "@/mixins/notify.js"
+import { timing } from "@/mixins/timing.js"
+import { CityService } from "@/services/CityService.js"
+import CountryService from "@/services/CountryService.js"
+import { MiniGridService } from "@/services/MiniGridService.js"
+import { EventBus } from "@/shared/eventbus.js"
+import Widget from "@/shared/Widget.vue"
+
+export default {
+  name: "Villages",
+  mixins: [notify, timing],
+  components: { Widget },
+  data() {
+    return {
+      subscriber: "village-list",
+      cityService: new CityService(),
+      miniGridService: new MiniGridService(),
+      countryService: new CountryService(),
+      villages: [],
+    }
+  },
+  mounted() {
+    this.loadVillages()
+  },
+  methods: {
+    async loadVillages() {
+      try {
+        const [villages] = await Promise.all([
+          this.cityService.getCities(),
+          this.miniGridService.getMiniGrids(),
+          this.countryService.getCountries(),
+        ])
+
+        this.villages = [...villages].sort((a, b) =>
+          (a.name || "").localeCompare(b.name || ""),
+        )
+        EventBus.$emit("widgetContentLoaded", this.subscriber, this.villages.length)
+      } catch (e) {
+        EventBus.$emit("widgetContentLoaded", this.subscriber, 0)
+        this.alertNotify("error", e.message)
+      }
+    },
+    getMiniGridName(miniGridId) {
+      const miniGrid = this.miniGridService.list.find(
+        (item) => item.id === miniGridId,
+      )
+      return miniGrid ? miniGrid.name : "-"
+    },
+    getCountryName(countryId) {
+      const country = this.countryService.list.find((item) => item.id === countryId)
+      return country ? country.name || country.country_name || "-" : "-"
+    },
+    goToVillageDetail(villageId) {
+      this.$router.push(`/villages/${villageId}`)
+    },
+    goToAddVillage() {
+      this.$router.push("/locations/add-village")
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/frontend/src/repositories/CityRepository.js
+++ b/src/frontend/src/repositories/CityRepository.js
@@ -6,7 +6,14 @@ export default {
   list() {
     return Client.get(`${resource}`)
   },
+  detail(cityId, withRelation = false) {
+    const query = withRelation ? "?relation=1" : ""
+    return Client.get(`${resource}/${cityId}${query}`)
+  },
   create(city) {
     return Client.post(`${resource}`, city)
+  },
+  update(cityId, city) {
+    return Client.put(`${resource}/${cityId}`, city)
   },
 }

--- a/src/frontend/src/services/CityService.js
+++ b/src/frontend/src/services/CityService.js
@@ -116,4 +116,33 @@ export class CityService {
       return new ErrorHandler(errorMessage, "http")
     }
   }
+
+  async getCity(cityId, withRelation = false) {
+    try {
+      const { data, status, error } = await this.repository.detail(
+        cityId,
+        withRelation,
+      )
+      if (status !== 200) return new ErrorHandler(error, "http", status)
+      this.city = data.data
+      return this.city
+    } catch (e) {
+      const errorMessage = e.response.data.message
+      return new ErrorHandler(errorMessage, "http")
+    }
+  }
+
+  async updateCity(cityId, cityData) {
+    try {
+      const params = convertObjectKeysToSnakeCase(cityData)
+      const { data, status, error } = await this.repository.update(cityId, params)
+      if (status !== 200 && status !== 201)
+        return new ErrorHandler(error, "http", status)
+      this.city = data.data
+      return this.city
+    } catch (e) {
+      const errorMessage = e.response.data.message
+      return new ErrorHandler(errorMessage, "http")
+    }
+  }
 }


### PR DESCRIPTION
### Brief summary of the change made

This PR adds a proper Village management flow so villages are no longer create-only.

What is included:
- A new **Village Overview** page at `/villages` to list existing villages.
- A new **Village Detail** page at `/villages/:id` to view and update village data.
- Route and sidebar integration for the new village pages.
- City API integration on the frontend for `detail` and `update` operations.

closes: #1364

### Are there any other side effects of this change that we should be aware of?

- No backend endpoint changes were needed; this uses existing `GET /api/cities/{id}` and `PUT /api/cities/{id}` endpoints.
- The village detail page is restricted to users with `settings` permission (consistent with village creation).

### Describe how you tested your changes?

Manual verification in local development:

1. Open `/villages` and confirm existing villages are listed.
2. Click any village row and verify navigation to `/villages/:id`.
3. Edit name/country/mini-grid as a settings user and save.
4. Confirm success notification and persisted values after reload.
5. Verify non-settings users can access view but cannot edit fields/save.

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [x] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
