### PR TITLE
fix: remove redundant minimum payable amount from Sell Appliance modal

### DIFF
--- a/src/frontend/src/modules/Client/Appliances/SellApplianceModal.vue
+++ b/src/frontend/src/modules/Client/Appliances/SellApplianceModal.vue
@@ -286,25 +286,6 @@
                     </span>
                   </md-field>
                 </div>
-                <div class="md-layout-item md-size-100 md-small-size-100">
-                  <md-field>
-                    <label for="minimumPayableAmount">
-                      {{
-                        applianceService.appliance.rateType === "weekly"
-                          ? $tc("phrases.minimumPayableAmount", 1)
-                          : $tc("phrases.minimumPayableAmount", 2)
-                      }}
-                    </label>
-                    <md-input
-                      type="number"
-                      id="minimumPayableAmount"
-                      name="minimumPayableAmount"
-                      v-model="minimumPayableAmount"
-                      readonly
-                      disabled
-                    />
-                  </md-field>
-                </div>
               </form>
             </md-tab>
           </md-tabs>
@@ -528,7 +509,6 @@ export default {
       selectedApplianceId: null,
       deviceSelectionList: [],
       isDeviceSelectionRequired: false,
-      minimumPayableAmount: 0,
       selectedDeviceSerial: null,
       showRates: false,
       loading: false,
@@ -822,8 +802,7 @@ export default {
       ) {
         this.applianceService.appliance.rate = 0
       }
-      this.minimumPayableAmount = 0
-      this.rateCost = 0
+      this.applianceService.appliance.rateCost = 0
     },
     calculateRateCountsOnRateCostChange() {
       const remainingCost =
@@ -835,18 +814,15 @@ export default {
           "warn",
           "Rate cost can not be bigger than remaining cost",
         )
-        this.minimumPayableAmount = 0
         this.applianceService.appliance.rate = 0
         return
       }
       if (installmentCost < 1 || typeof installmentCost !== "number") {
-        this.minimumPayableAmount = 0
         this.applianceService.appliance.rate = 0
         return
       }
-      this.minimumPayableAmount = Math.floor(installmentCost)
       this.applianceService.appliance.rate = Math.floor(
-        remainingCost / this.minimumPayableAmount,
+        remainingCost / installmentCost,
       )
     },
     isDeviceBindingRequired(appliance) {


### PR DESCRIPTION
## Summary
This removes the read-only Minimum Payable Amount field from the cost-based Sell Appliance modal.

## Why this should be removed
I traced the field through the current modal, the deferred-payment flow, and the backend payment validation.

In the active Sell Appliance modal, Minimum Payable Amount is not a separate input and it does not represent a second business rule. It is derived directly from the installment amount the user already entered.

On the backend, the real minimum accepted payment for this flow already comes from the installment schedule itself: deferred appliance payments are rejected when the payment amount is below one installment. Because of that, showing both Rate Cost and Minimum Payable Amount in this modal makes the UI look like there are two different values to configure, when in practice there is only one.

That extra field adds noise, creates avoidable confusion, and does not help the operator make a better decision.

## What changed
- removed the read-only Minimum Payable Amount field from the cost-based Sell Appliance view
- removed the unused minimumPayableAmount state from the active modal
- simplified the rate count calculation so it works directly from the installment amount
- fixed the down-payment recalculation path to reset applianceService.appliance.rateCost instead of a stray this.rateCost

## Scope
I kept this PR intentionally narrow.

I did not touch the older SellApplianceCard flow in this change. That legacy SHS and tariff path still uses the same concept historically when creating a tariff, and folding that into this PR would make the review less clear.

## Validation
- checked the updated Vue file with editor diagnostics; no errors reported
