### PR TITLE
fix: add explicit compose network aliases for mysql and redis

### DIFF
--- a/docker-compose-dockerhub.yml
+++ b/docker-compose-dockerhub.yml
@@ -86,6 +86,10 @@ services:
       - redis_data:/data
     ports:
       - 6379:6379
+    networks:
+      default:
+        aliases:
+          - redis
 
   mysql:
     container_name: mysql
@@ -99,6 +103,11 @@ services:
       - mysql_data:/var/lib/mysql
     ports:
       - 3306:3306
+    networks:
+      default:
+        aliases:
+          - db
+          - mysql
     healthcheck:
       test: [CMD, mysqladmin, ping, -h, localhost]
       start_period: 10s

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -90,6 +90,10 @@ services:
       - redis_data:/data
     ports:
       - 6379:6379
+    networks:
+      default:
+        aliases:
+          - redis
 
   mysql:
     container_name: mysql
@@ -103,6 +107,11 @@ services:
       - mysql_data:/var/lib/mysql
     ports:
       - 3306:3306
+    networks:
+      default:
+        aliases:
+          - db
+          - mysql
     healthcheck:
       test: [CMD, mysqladmin, ping, -h, localhost]
       start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,10 @@ services:
       - redis_data:/data
     ports:
       - 6379:6379
+    networks:
+      default:
+        aliases:
+          - redis
 
   mysql:
     container_name: mysql
@@ -112,6 +116,11 @@ services:
       - mysql_data:/var/lib/mysql
     ports:
       - 3306:3306
+    networks:
+      default:
+        aliases:
+          - db
+          - mysql
     healthcheck:
       test: [CMD, mysqladmin, ping, -h, localhost]
       start_period: 10s


### PR DESCRIPTION
### Brief summary of the change made

This PR adds explicit Docker Compose default-network aliases for database/cache services to avoid DNS resolution failures in local and compose-based setups.

- `mysql` now has aliases: `db`, `mysql`
- `redis` now has alias: `redis`

Updated files:
- `docker-compose.yml`
- `docker-compose-prod.yml`
- `docker-compose-dockerhub.yml`

closes: #1374

### Are there any other side effects of this change that we should be aware of?

No functional side effects expected. This only makes service discovery explicit and more reliable.

### Describe how you tested your changes?

Manual validation:

1. Recreated the stack:
   - `docker compose up -d --force-recreate`
2. Verified service hostname resolution from backend container:
   - `db`, `mysql`, and `redis` now resolve to container IPs.
3. Verified backend auth endpoint with seeded demo credentials:
   - `POST /api/auth/login` with `demo_company_admin@example.com` / `123123`
   - received valid JWT token.
4. Verified frontend responds on `http://localhost:8001`.

### Pull Request checklist

- [x] Meaningful Pull Request title and description
- [x] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.
