### PR TITLE
Remove global styling in `SideBar.vue`

### DIFF
--- a/src/frontend/src/assets/sass/mpm/_sidebar-and-main-panel.scss
+++ b/src/frontend/src/assets/sass/mpm/_sidebar-and-main-panel.scss
@@ -30,18 +30,20 @@
   background-position: center center;
   @extend .animation-transition-general;
 
-  .md-icon.md-theme-default.md-icon-font,
-  .material-icons {
-    color: #fff !important;
-    opacity: 0.8;
-  }
-
   .md-list {
     &.nav {
       position: initial;
     }
 
     background-color: transparent !important;
+
+    .md-list-item * {
+      color: white;
+    }
+
+    .md-icon.md-theme-default.md-icon-image svg {
+      fill: white;
+    }
 
     .md-list-item a {
       text-transform: capitalize;

--- a/src/frontend/src/layouts/MobileTopNavbar.vue
+++ b/src/frontend/src/layouts/MobileTopNavbar.vue
@@ -21,7 +21,7 @@
         <div class="md-layout-item md-layout md-gutter nav-menu">
           <md-menu md-direction="bottom-end" md-size="medium" class="menu-item">
             <md-button class="md-dense nav-button" md-menu-trigger>
-              <md-icon class="c-white">add_location_alt</md-icon>
+              <md-icon>add_location_alt</md-icon>
               <small>{{ $tc("words.location", 2) }}</small>
             </md-button>
             <md-menu-content>
@@ -51,7 +51,7 @@
           </md-menu>
           <md-menu class="menu-item" md-direction="bottom-end" md-size="medium">
             <md-button class="md-dense nav-button" md-menu-trigger>
-              <md-icon class="c-white">settings</md-icon>
+              <md-icon>settings</md-icon>
               <small class="mobile-menu-text">
                 {{ $tc("menu.subMenu.Settings") }}
               </small>
@@ -96,11 +96,11 @@
           </md-menu>
           <md-menu class="menu-item" md-direction="bottom-end" md-size="medium">
             <md-button class="nav-button md-dense" md-menu-trigger>
-              <md-icon class="c-white">person</md-icon>
+              <md-icon>person</md-icon>
               <small class="mobile-menu-text">
                 {{ adminName }}
               </small>
-              <md-icon class="c-white">keyboard_arrow_down</md-icon>
+              <md-icon>keyboard_arrow_down</md-icon>
             </md-button>
             <md-menu-content>
               <div class="author-card">
@@ -180,6 +180,14 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.md-button.nav-button {
+  color: white;
+}
+
+.md-icon.md-icon-font.md-theme-default {
+  color: white;
+}
+
 @media screen and (max-width: 500px) {
   .mobile-menu-text {
     display: none;

--- a/src/frontend/src/layouts/TopNavbar.vue
+++ b/src/frontend/src/layouts/TopNavbar.vue
@@ -12,7 +12,7 @@
               <md-tooltip md-direction="bottom">
                 {{ $tc("words.location", 2) }}
               </md-tooltip>
-              <md-icon class="c-white">add_location_alt</md-icon>
+              <md-icon>add_location_alt</md-icon>
               <small>{{ $tc("words.location", 2) }}</small>
             </md-button>
             <md-menu-content>
@@ -37,7 +37,7 @@
               <md-tooltip md-direction="bottom">
                 {{ $tc("menu.subMenu.Settings") }}
               </md-tooltip>
-              <md-icon class="c-white">settings</md-icon>
+              <md-icon>settings</md-icon>
               <small>{{ $tc("menu.subMenu.Settings") }}</small>
             </md-button>
             <md-menu-content>
@@ -70,9 +70,9 @@
           </md-menu>
           <md-menu class="menu-item" md-direction="bottom-end" md-size="big">
             <md-button class="nav-button md-raised md-dense" md-menu-trigger>
-              <md-icon class="c-white">person</md-icon>
+              <md-icon>person</md-icon>
               <small>{{ adminName }}</small>
-              <md-icon class="c-white">keyboard_arrow_down</md-icon>
+              <md-icon>keyboard_arrow_down</md-icon>
             </md-button>
             <md-menu-content>
               <div class="author-card">
@@ -133,9 +133,16 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.nav-button {
-  background-color: #3d3d3d !important;
-  color: white !important;
+.md-button.md-theme-default.md-raised.nav-button {
+  background-color: #3d3d3d;
+}
+
+.md-toolbar.md-theme-default * {
+  color: white;
+}
+
+.md-toolbar.md-theme-default .md-icon {
+  color: white;
 }
 
 .menu-item {
@@ -150,9 +157,5 @@ export default {
   font-weight: 300;
   padding: 1vh;
   margin-top: 0;
-}
-
-.c-white {
-  color: white;
 }
 </style>

--- a/src/frontend/src/modules/Sidebar/SideBar.vue
+++ b/src/frontend/src/modules/Sidebar/SideBar.vue
@@ -25,13 +25,10 @@
               :key="'menu' + menu.meta?.sidebar?.name ?? menu.path"
             >
               <md-list-item>
-                <md-icon
-                  v-if="menu.meta?.sidebar?.icon"
-                  class="c-white icon-box"
-                >
+                <md-icon v-if="menu.meta?.sidebar?.icon" class="icon-box">
                   {{ menu.meta.sidebar.icon }}
                 </md-icon>
-                <span class="md-list-item-text c-white">
+                <span class="md-list-item-text">
                   {{ $tc("menu." + menu.meta?.sidebar?.name ?? menu.path) }}
                 </span>
               </md-list-item>
@@ -43,13 +40,10 @@
               :key="'submenu' + menu.meta?.sidebar?.name ?? menu.path"
             >
               <md-list-item md-expand>
-                <md-icon
-                  v-if="menu.meta?.sidebar?.icon"
-                  class="c-white icon-box"
-                >
+                <md-icon v-if="menu.meta?.sidebar?.icon" class="icon-box">
                   {{ menu.meta.sidebar.icon }}
                 </md-icon>
-                <span class="md-list-item-text c-white">
+                <span class="md-list-item-text">
                   {{ menu.meta?.sidebar?.name ?? menu.path }}
                 </span>
                 <md-list slot="md-expand" class="no-bg">
@@ -61,7 +55,7 @@
                       class="sub-menu"
                     >
                       <md-list-item>
-                        <span class="md-list-item-text c-white">
+                        <span class="md-list-item-text">
                           {{
                             $tc(
                               "menu.subMenu." + sub.meta?.sidebar?.name ??
@@ -209,21 +203,13 @@ export default {
 }
 </script>
 
-<!-- https://github.com/EnAccess/micropowermanager/issues/1256 -->
-<!-- eslint-disable vue/enforce-style-attribute -->
-<style lang="scss">
+<style scoped lang="scss">
 .sidebar {
   background: #2b2b2b;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1;
-  width: 260px;
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
+
 .sidebar-wrapper {
   position: relative;
   z-index: 4;
@@ -308,14 +294,6 @@ export default {
 
 .no-bg {
   background-color: transparent !important;
-}
-
-.md-icon.md-theme-default.md-icon-image svg {
-  fill: #f5e8e8 !important;
-}
-
-.c-white {
-  color: #f5e8e8 !important;
 }
 
 .icon-box {

--- a/src/frontend/src/modules/Transactions/Transaction.vue
+++ b/src/frontend/src/modules/Transactions/Transaction.vue
@@ -503,7 +503,7 @@ export default {
 
 .message-box {
   padding: 10px;
-  background-color: #f5e8e8;
+  background-color: white;
   -moz-border-radius: 10px;
   border-radius: 14px;
   margin-top: 2vh;

--- a/src/frontend/src/shared/Paginate.vue
+++ b/src/frontend/src/shared/Paginate.vue
@@ -191,7 +191,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped lang="scss">
 .md-table-pagination {
   height: 56px;
   display: flex;
@@ -226,10 +226,5 @@ export default {
   max-width: 82px;
   min-width: 56px;
   margin-top: 5px;
-}
-
-// Workaround to fight global styling from SideBar.vue
-::v-deep(.md-icon.md-theme-default.md-icon-image svg) {
-  fill: rgba(0, 0, 0, 0.87) !important;
 }
 </style>


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Closes: #1256 

Goal of the PR is to remove the global styling in `SideBar.vue` which had side effects in other components. Fixing components that implicitly relied on the global styling like `TopBar`.

Additionally, this improves this like visibility in other components like sorted lists

**Before:**

<img width="301" height="99" alt="image" src="https://github.com/user-attachments/assets/bd835efe-229d-4cd4-889a-d0c3a7741eea" />


**After:**

<img width="352" height="103" alt="image" src="https://github.com/user-attachments/assets/58641b6d-4a4f-4eb3-a927-5be7cd1b277c" />


### Are there any other side effects of this change that we should be aware of?

Previously, we are were actually using three different colors in the side bar

<img width="625" height="208" alt="image" src="https://github.com/user-attachments/assets/84f45ca5-75bd-40bc-afb3-5f8d63a28030" />

It's very hard to see with human eyes, best checked with a Digital Colour Meter

- The icon was using 80% white
- The word `Dashboard` is 100% `#f5e8e8`
- The down arrow is 80% `#f5e8e8`

The current PR changes this to use 100% white everywhere. While this is slightly less eye-friendly it increases the consistency in the code for future improvements.


### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
