### PR TITLE
Update SunKing default URL's to prod

### DIFF
--- a/docs/installation/environment-variables.md
+++ b/docs/installation/environment-variables.md
@@ -209,10 +209,10 @@ Find below a reference of configurations which are required if the corresponding
 
 For detailed information see [SunKing Developer Documentation](https://sunking.com/)
 
-| Environment Variable       | Default                                                                              | Description                                                                                                   |
-| -------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| `SUNKING_AUTH_DEFAULT_URL` | `https://auth.central.glpapps.com/auth/realms/glp-dev/protocol/openid-connect/token` | Default authorisation URL used when tenants activate the SunKing plugin on the instance of MicroPowerManager. |
-| `SUNKING_API_DEFAULT_URL`  | `https://dev.assetcontrol.central.glpapps.com/v2`                                    | Default API URL used when tenants activate the SunKing plugin on the instance of MicroPowerManager.           |
+| Environment Variable       | Default                                                                          | Description                                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `SUNKING_AUTH_DEFAULT_URL` | `https://auth.central.glpapps.com/auth/realms/glp/protocol/openid-connect/token` | Default authorisation URL used when tenants activate the SunKing plugin on the instance of MicroPowerManager. |
+| `SUNKING_API_DEFAULT_URL`  | `https://assetcontrol.central.glpapps.com/v2`                                    | Default API URL used when tenants activate the SunKing plugin on the instance of MicroPowerManager.           |
 
 #### WaveMoney
 

--- a/src/backend/config/sunking-shs.php
+++ b/src/backend/config/sunking-shs.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'default_auth_url' => env('SUNKING_DEFAULT_AUTH_URL', 'https://auth.central.glpapps.com/auth/realms/glp-dev/protocol/openid-connect/token'),
-    'default_api_url' => env('SUNKING_DEFAULT_API_URL', 'https://dev.assetcontrol.central.glpapps.com/v2'),
+    'default_auth_url' => env('SUNKING_DEFAULT_AUTH_URL', 'https://auth.central.glpapps.com/auth/realms/glp/protocol/openid-connect/token'),
+    'default_api_url' => env('SUNKING_DEFAULT_API_URL', 'https://assetcontrol.central.glpapps.com/v2'),
 ];


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Change the default values of SunKing plugin to point to prod. These simply represent the pre-populated values if a tenant's enables Sunking plugin for the first time.

Using the `-dev` values should only be required during development of SunKing plugin or testing in conjuction with SunKing. In all other cases the Prod values should be uses. 

If dev values are required they can simply be changed via the UI.

So, this PR should streamline the flow for 99% or the users.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
