### PR TITLE
Prefer use of `$request->integer(...)` over string casting

### DIFF
--- a/src/backend/app/Http/Controllers/AppliancePersonController.php
+++ b/src/backend/app/Http/Controllers/AppliancePersonController.php
@@ -81,8 +81,8 @@ class AppliancePersonController extends Controller {
         $appliancePerson = $this->appliancePersonService->make([
             'appliance_id' => $request->input('id'),
             'person_id' => $request->input('person_id'),
-            'total_cost' => $isEnergyService ? 0 : (int) $request->input('cost'),
-            'rate_count' => $isEnergyService ? 0 : (int) $request->input('rate'),
+            'total_cost' => $isEnergyService ? 0 : $request->integer('cost'),
+            'rate_count' => $isEnergyService ? 0 : $request->integer('rate'),
             'down_payment' => (float) $request->input('down_payment', 0),
             'device_serial' => $request->input('device_serial'),
             'payment_type' => $paymentType,

--- a/src/backend/app/Http/Controllers/DeviceController.php
+++ b/src/backend/app/Http/Controllers/DeviceController.php
@@ -13,7 +13,7 @@ class DeviceController extends Controller {
     public function __construct(private DeviceService $deviceService) {}
 
     public function index(Request $request): ApiResource {
-        $limit = (int) $request->input('per_page', 15);
+        $limit = $request->integer('per_page', 15);
         $filters = $request->only(['device_type', 'appliance_id', 'unassigned']);
 
         return ApiResource::make($this->deviceService->getAll($limit, $filters));

--- a/src/backend/app/Http/Controllers/TicketCommentController.php
+++ b/src/backend/app/Http/Controllers/TicketCommentController.php
@@ -14,7 +14,7 @@ class TicketCommentController extends Controller {
     public function store(Request $request): void {
         /** @var User $user */
         $user = Auth::user();
-        $ticketId = (int) $request->input('cardId');
+        $ticketId = $request->integer('cardId');
         $comment = $request->input('comment');
 
         $ticketUser = $this->ticketUserService->findOrCreateByUser($user);

--- a/src/backend/app/Http/Controllers/TransactionAdvancedController.php
+++ b/src/backend/app/Http/Controllers/TransactionAdvancedController.php
@@ -22,7 +22,7 @@ class TransactionAdvancedController extends Controller {
         $status = $request->input('status');
         $fromDate = $request->input('from');
         $toDate = $request->input('to');
-        $limit = $request->integer('per_page', '15');
+        $limit = $request->integer('per_page', 15);
 
         return ApiResource::make($this->transactionService->search(
             $deviceType,

--- a/src/backend/app/Http/Controllers/TransactionAdvancedController.php
+++ b/src/backend/app/Http/Controllers/TransactionAdvancedController.php
@@ -22,7 +22,7 @@ class TransactionAdvancedController extends Controller {
         $status = $request->input('status');
         $fromDate = $request->input('from');
         $toDate = $request->input('to');
-        $limit = (int) $request->input('per_page', '15');
+        $limit = $request->integer('per_page', '15');
 
         return ApiResource::make($this->transactionService->search(
             $deviceType,

--- a/src/backend/app/Plugins/KelinMeter/Services/KelinCustomerService.php
+++ b/src/backend/app/Plugins/KelinMeter/Services/KelinCustomerService.php
@@ -234,7 +234,7 @@ class KelinCustomerService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, KelinCustomer>
      */
     public function getCustomers(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->kelinCustomer->newQuery()->with(['mpmPerson.addresses'])->paginate($perPage);
     }

--- a/src/backend/app/Plugins/KelinMeter/Services/KelinMeterService.php
+++ b/src/backend/app/Plugins/KelinMeter/Services/KelinMeterService.php
@@ -51,7 +51,7 @@ class KelinMeterService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, KelinMeter>
      */
     public function getMeters(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->kelinMeter->newQuery()->with([
             'mpmMeter',

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackController.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackController.php
@@ -68,7 +68,7 @@ class PaystackController extends Controller {
      * @return JsonResponse
      */
     public function getTransactions(Request $request) {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
         $transactions = $this->transactionService->getAll($perPage);
 
         return response()->json($transactions);

--- a/src/backend/app/Plugins/SparkMeter/Services/CustomerService.php
+++ b/src/backend/app/Plugins/SparkMeter/Services/CustomerService.php
@@ -49,7 +49,7 @@ class CustomerService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SmCustomer>
      */
     public function getSmCustomers(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->smCustomer->newQuery()->with(['mpmPerson', 'site.mpmMiniGrid'])->paginate($perPage);
     }

--- a/src/backend/app/Plugins/SparkMeter/Services/MeterModelService.php
+++ b/src/backend/app/Plugins/SparkMeter/Services/MeterModelService.php
@@ -33,7 +33,7 @@ class MeterModelService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SmMeterModel>
      */
     public function getSmMeterModels(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->smMeterModel->newQuery()->with(['meterType', 'site.mpmMiniGrid'])->paginate($perPage);
     }

--- a/src/backend/app/Plugins/SparkMeter/Services/SiteService.php
+++ b/src/backend/app/Plugins/SparkMeter/Services/SiteService.php
@@ -39,7 +39,7 @@ class SiteService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SmSite>
      */
     public function getSmSites(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
         $sites = $this->site->newQuery()->with('mpmMiniGrid')->paginate($perPage);
 
         foreach ($sites as $site) {

--- a/src/backend/app/Plugins/SparkMeter/Services/SmSalesAccoutService.php
+++ b/src/backend/app/Plugins/SparkMeter/Services/SmSalesAccoutService.php
@@ -31,7 +31,7 @@ class SmSalesAccoutService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SmSalesAccount>
      */
     public function getSmSalesAccounts(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->smSalesAccount->newQuery()->with(['site.mpmMiniGrid'])->paginate($perPage);
     }

--- a/src/backend/app/Plugins/SparkMeter/Services/TariffService.php
+++ b/src/backend/app/Plugins/SparkMeter/Services/TariffService.php
@@ -113,7 +113,7 @@ class TariffService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SmTariff>
      */
     public function getSmTariffs(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->smTariff->newQuery()->with(['mpmTariff', 'site.mpmMiniGrid'])->paginate($perPage);
     }

--- a/src/backend/app/Plugins/SteamaMeter/Services/SteamaAgentService.php
+++ b/src/backend/app/Plugins/SteamaMeter/Services/SteamaAgentService.php
@@ -40,7 +40,7 @@ class SteamaAgentService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SteamaAgent>
      */
     public function getAgents(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->stmAgent->newQuery()->with(['mpmAgent.person.addresses', 'site.mpmMiniGrid'])->paginate($perPage);
     }

--- a/src/backend/app/Plugins/SteamaMeter/Services/SteamaCustomerService.php
+++ b/src/backend/app/Plugins/SteamaMeter/Services/SteamaCustomerService.php
@@ -54,7 +54,7 @@ class SteamaCustomerService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SteamaCustomer>
      */
     public function getCustomers(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->customer->newQuery()->with(['mpmPerson.addresses', 'site.mpmMiniGrid'])->paginate($perPage);
     }

--- a/src/backend/app/Plugins/SteamaMeter/Services/SteamaMeterService.php
+++ b/src/backend/app/Plugins/SteamaMeter/Services/SteamaMeterService.php
@@ -48,7 +48,7 @@ class SteamaMeterService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SteamaMeter>
      */
     public function getMeters(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->stmMeter->newQuery()->with([
             'mpmMeter',

--- a/src/backend/app/Plugins/SteamaMeter/Services/SteamaSiteService.php
+++ b/src/backend/app/Plugins/SteamaMeter/Services/SteamaSiteService.php
@@ -37,7 +37,7 @@ class SteamaSiteService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SteamaSite>
      */
     public function getSites(Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->site->newQuery()->with('mpmMiniGrid.location')->paginate($perPage);
     }

--- a/src/backend/app/Plugins/SteamaMeter/Services/SteamaTransactionsService.php
+++ b/src/backend/app/Plugins/SteamaMeter/Services/SteamaTransactionsService.php
@@ -152,7 +152,7 @@ class SteamaTransactionsService implements ISynchronizeService {
      * @return LengthAwarePaginator<int, SteamaTransaction>
      */
     public function getTransactionsByCustomer(SteamaCustomer $customer, Request $request): LengthAwarePaginator {
-        $perPage = (int) $request->input('per_page', 15);
+        $perPage = $request->integer('per_page', 15);
 
         return $this->steamaTransaction->newQuery()->where('customer_id', $customer)->paginate($perPage);
     }

--- a/src/backend/app/Plugins/WaveMoneyPaymentProvider/Http/Requests/TransactionCallbackRequestMapper.php
+++ b/src/backend/app/Plugins/WaveMoneyPaymentProvider/Http/Requests/TransactionCallbackRequestMapper.php
@@ -39,7 +39,7 @@ class TransactionCallbackRequestMapper {
             $request->input(self::BODY_PARAM_BACKEND_RESULT_URL),
             $request->input(self::BODY_PARAM_INITIATOR_MSISDN),
             floatval($request->input(self::BODY_PARAM_AMOUNT)),
-            (int) $request->input(self::BODY_PARAM_TIME_TO_LIVE_SECONDS),
+            $request->integer(self::BODY_PARAM_TIME_TO_LIVE_SECONDS),
             $request->input(self::BODY_PARAM_PAYMENT_DESCRIPTION),
             $request->input(self::BODY_PARAM_CURRENCY),
             $request->input(self::BODY_PARAM_HASH_VALUE),


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Litte find&replace clean up to prefer 

```php
$request->integer('per_page', 15);
```

over

```php
(int) $request->input('per_page', 15);
```

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
