### PR TITLE
Add missing `allClusters` to `pt`

### DIFF
--- a/src/frontend/src/assets/locales/pt.json
+++ b/src/frontend/src/assets/locales/pt.json
@@ -128,6 +128,7 @@
     "agentTicket": "Bilhete do Agente | Bilhetes do Agente",
     "agentTransaction": "Transacção do Agente | Transacções do Agente",
     "agentUpdatedSuccess": "Agente Actualizado com Sucesso",
+    "allClusters": "Todos os Agrupamentos",
     "allNetworkProviders": "Todos os Provedores de Rede",
     "allTariffs": "Todas as Tarifas",
     "allTransactions": "Todas as Transacções",


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Fixing [semantic merge conflict](https://martinfowler.com/bliki/SemanticConflict.html) between https://github.com/EnAccess/micropowermanager/pull/1433 and https://github.com/EnAccess/micropowermanager/pull/1438

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
