### PR TITLE
Add `clusters_created_at_index` to fix OOM errors in `clusters` table…

### DIFF
--- a/src/backend/database/migrations/tenant/2026_06_04_080755_add_sort_index_to_clusters_table.php
+++ b/src/backend/database/migrations/tenant/2026_06_04_080755_add_sort_index_to_clusters_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::connection('tenant')->table('clusters', function (Blueprint $table) {
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::connection('tenant')->table('clusters', function (Blueprint $table) {
+            $table->dropIndex('clusters_created_at_index');
+        });
+    }
+};


### PR DESCRIPTION
… queries

<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This adds a simple index of `created_at` for `clusters` table.

There seems to be a somewhat opaque interaction between MySQL sorting and our JSON columns. Adding an index fixes it.

**Steps to reproduce:**

- Add a new cluster `Mozambique` with the GeoJSON from OSM
- Run `select * from `clusters` order by `created_at` desc limit 1;`
- Yields: `Query 1 ERROR at Line 1: : Out of sort memory, consider increasing server sort buffer size`

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
