### PR TITLE
Rename Payment Initiator

### DIFF
--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -154,15 +154,15 @@ class InstallPackage extends Command
 
 If your plugin is a **payment provider** (processes transactions from an external payment gateway), there are additional integration steps required:
 
-1. **Implement the `PaymentInitializer` interface**
+1. **Implement the `PaymentInitiator` interface**
 
-   Your plugin's transaction service must implement `App\Services\Interfaces\PaymentInitializer`. This enforces a consistent `initializePayment()` method that creates the provider-specific record and an associated `Transaction` entry.
+   Your plugin's transaction service must implement `App\Services\Interfaces\PaymentInitiator`. This enforces a consistent `initiatePayment()` method that creates the provider-specific record and an associated `Transaction` entry.
 
    ```php
-   use App\Services\Interfaces\PaymentInitializer;
+   use App\Services\Interfaces\PaymentInitiator;
 
-   class YourProviderTransactionService implements PaymentInitializer {
-       public function initializePayment(
+   class YourProviderTransactionService implements PaymentInitiator {
+       public function initiatePayment(
            float $amount,
            string $sender,
            string $message,
@@ -180,7 +180,7 @@ If your plugin is a **payment provider** (processes transactions from an externa
 
 2. **Register in the provider map**
 
-   Add your plugin's MpmPlugin ID and service class to the `PROVIDER_MAP` constant in `App\Services\PaymentInitializationService`:
+   Add your plugin's MpmPlugin ID and service class to the `PROVIDER_MAP` constant in `App\Services\PaymentInitiationService`:
 
    ```php
    private const PROVIDER_MAP = [

--- a/src/backend/app/Http/Controllers/AppliancePaymentController.php
+++ b/src/backend/app/Http/Controllers/AppliancePaymentController.php
@@ -8,7 +8,7 @@ use App\Models\AppliancePerson;
 use App\Models\Transaction\Transaction;
 use App\Services\AppliancePaymentService;
 use App\Services\AppliancePersonService;
-use App\Services\PaymentInitializationService;
+use App\Services\PaymentInitiationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -19,7 +19,7 @@ class AppliancePaymentController extends Controller {
     public function __construct(
         private AppliancePaymentService $appliancePaymentService,
         private AppliancePersonService $appliancePersonService,
-        private PaymentInitializationService $paymentInitializationService,
+        private PaymentInitiationService $paymentInitiationService,
     ) {}
 
     public function store(AppliancePerson $appliancePerson, Request $request): ApiResource|JsonResponse {
@@ -52,7 +52,7 @@ class AppliancePaymentController extends Controller {
     }
 
     public function paymentProviders(): ApiResource {
-        $providers = $this->paymentInitializationService->paymentProviders();
+        $providers = $this->paymentInitiationService->paymentProviders();
 
         return ApiResource::make($providers);
     }
@@ -79,7 +79,7 @@ class AppliancePaymentController extends Controller {
 
         $message = $deviceSerial ?? (string) $appliancePerson->id;
 
-        $result = $this->paymentInitializationService->initialize(
+        $result = $this->paymentInitiationService->initiate(
             providerId: $providerId,
             amount: $amount,
             sender: $sender,

--- a/src/backend/app/Http/Controllers/AppliancePersonController.php
+++ b/src/backend/app/Http/Controllers/AppliancePersonController.php
@@ -18,7 +18,7 @@ use App\Services\ApplianceRateService;
 use App\Services\ApplianceService;
 use App\Services\DeviceService;
 use App\Services\GeographicalInformationService;
-use App\Services\PaymentInitializationService;
+use App\Services\PaymentInitiationService;
 use App\Services\UserAppliancePersonService;
 use App\Services\UserService;
 use Illuminate\Http\Request;
@@ -37,7 +37,7 @@ class AppliancePersonController extends Controller {
         private AddressesService $addressesService,
         private GeographicalInformationService $geographicalInformationService,
         private AddressGeographicalInformationService $addressGeographicalInformationService,
-        private PaymentInitializationService $paymentInitializationService,
+        private PaymentInitiationService $paymentInitiationService,
         private ApplianceService $applianceService,
         private ApplianceRateService $applianceRateService,
     ) {}
@@ -152,7 +152,7 @@ class AppliancePersonController extends Controller {
         $companyId = $request->attributes->get('companyId');
         $downPaymentInitData = [];
 
-        $result = $this->paymentInitializationService->initialize(
+        $result = $this->paymentInitiationService->initiate(
             providerId: $paymentProviderId,
             amount: $downPayment,
             sender: $sender,

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackController.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackController.php
@@ -28,7 +28,7 @@ class PaystackController extends Controller {
         $amount = (float) $request->input('amount');
         $sender = $this->transactionService->getCustomerPhoneByCustomerId($customerId) ?? '';
 
-        $result = $this->transactionService->initializePayment(
+        $result = $this->transactionService->initiatePayment(
             amount: $amount,
             sender: $sender,
             message: $serialId,

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackPublicController.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackPublicController.php
@@ -82,7 +82,7 @@ class PaystackPublicController extends Controller {
 
             $sender = $this->transactionService->getCustomerPhoneByCustomerId($customerId) ?? '';
 
-            $result = $this->transactionService->initializePayment(
+            $result = $this->transactionService->initiatePayment(
                 amount: (float) $validatedData['amount'],
                 sender: $sender,
                 message: $deviceSerial,

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Services/PaystackTransactionService.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Services/PaystackTransactionService.php
@@ -14,7 +14,7 @@ use App\Plugins\PaystackPaymentProvider\Modules\Api\PaystackApiService;
 use App\Services\AbstractPaymentAggregatorTransactionService;
 use App\Services\DeviceService;
 use App\Services\Interfaces\IBaseService;
-use App\Services\Interfaces\PaymentInitializer;
+use App\Services\Interfaces\PaymentInitiator;
 use App\Services\PersonService;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -24,7 +24,7 @@ use Ramsey\Uuid\Uuid;
 /**
  * @implements IBaseService<PaystackTransaction>
  */
-class PaystackTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService, PaymentInitializer {
+class PaystackTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService, PaymentInitiator {
     public function __construct(
         private Meter $meter,
         private Address $address,
@@ -165,7 +165,7 @@ class PaystackTransactionService extends AbstractPaymentAggregatorTransactionSer
      *
      * @return array{transaction: Transaction, provider_data: array<string, mixed>}
      */
-    public function initializePayment(
+    public function initiatePayment(
         float $amount,
         string $sender,
         string $message,

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Tests/Unit/PaystackTransactionServiceInitiatePaymentTest.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Tests/Unit/PaystackTransactionServiceInitiatePaymentTest.php
@@ -11,7 +11,7 @@ use App\Plugins\PaystackPaymentProvider\Services\PaystackTransactionService;
 use Tests\RefreshMultipleDatabases;
 use Tests\TestCase;
 
-class PaystackTransactionServiceInitializePaymentTest extends TestCase {
+class PaystackTransactionServiceInitiatePaymentTest extends TestCase {
     use RefreshMultipleDatabases;
 
     /**
@@ -36,7 +36,7 @@ class PaystackTransactionServiceInitializePaymentTest extends TestCase {
             'reference' => 'ref_test_123',
         ]);
 
-        $result = $service->initializePayment(
+        $result = $service->initiatePayment(
             amount: 200.0,
             sender: '+2340000',
             message: '42',
@@ -64,7 +64,7 @@ class PaystackTransactionServiceInitializePaymentTest extends TestCase {
             'reference' => 'ref_serial',
         ]);
 
-        $service->initializePayment(
+        $service->initiatePayment(
             amount: 150.0,
             sender: '+2340001',
             message: 'SERIAL-XYZ',
@@ -90,7 +90,7 @@ class PaystackTransactionServiceInitializePaymentTest extends TestCase {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Paystack initialization failed: API error: invalid key');
 
-        $service->initializePayment(
+        $service->initiatePayment(
             amount: 100.0,
             sender: '-',
             message: '1',

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Http/Controllers/PesapalController.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Http/Controllers/PesapalController.php
@@ -23,7 +23,7 @@ class PesapalController extends Controller {
         $amount = (float) $request->input('amount');
         $sender = $this->transactionService->getCustomerPhoneByCustomerId($customerId) ?? '';
 
-        $result = $this->transactionService->initializePayment(
+        $result = $this->transactionService->initiatePayment(
             amount: $amount,
             sender: $sender,
             message: $serialId,

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Http/Controllers/PesapalPublicController.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Http/Controllers/PesapalPublicController.php
@@ -77,7 +77,7 @@ class PesapalPublicController extends Controller {
 
             $sender = $this->transactionService->getCustomerPhoneByCustomerId($customerId) ?? '';
 
-            $result = $this->transactionService->initializePayment(
+            $result = $this->transactionService->initiatePayment(
                 amount: (float) $validatedData['amount'],
                 sender: $sender,
                 message: $deviceSerial,

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Services/PesapalTransactionService.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Services/PesapalTransactionService.php
@@ -15,7 +15,7 @@ use App\Plugins\PesapalPaymentProvider\Modules\Api\Resources\GetTransactionStatu
 use App\Services\AbstractPaymentAggregatorTransactionService;
 use App\Services\DeviceService;
 use App\Services\Interfaces\IBaseService;
-use App\Services\Interfaces\PaymentInitializer;
+use App\Services\Interfaces\PaymentInitiator;
 use App\Services\PersonService;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -25,7 +25,7 @@ use Ramsey\Uuid\Uuid;
 /**
  * @implements IBaseService<PesapalTransaction>
  */
-class PesapalTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService, PaymentInitializer {
+class PesapalTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService, PaymentInitiator {
     public function __construct(
         private Meter $meter,
         private Address $address,
@@ -205,7 +205,7 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
     /**
      * @return array{transaction: Transaction, provider_data: array<string, mixed>}
      */
-    public function initializePayment(
+    public function initiatePayment(
         float $amount,
         string $sender,
         string $message,

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Tests/Unit/PesapalTransactionServiceInitiatePaymentTest.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Tests/Unit/PesapalTransactionServiceInitiatePaymentTest.php
@@ -11,7 +11,7 @@ use App\Plugins\PesapalPaymentProvider\Services\PesapalTransactionService;
 use Tests\RefreshMultipleDatabases;
 use Tests\TestCase;
 
-class PesapalTransactionServiceInitializePaymentTest extends TestCase {
+class PesapalTransactionServiceInitiatePaymentTest extends TestCase {
     use RefreshMultipleDatabases;
 
     /**
@@ -37,7 +37,7 @@ class PesapalTransactionServiceInitializePaymentTest extends TestCase {
             'merchant_reference' => 'mr_test_123',
         ]);
 
-        $result = $service->initializePayment(
+        $result = $service->initiatePayment(
             amount: 200.0,
             sender: '+254700000000',
             message: '42',
@@ -67,7 +67,7 @@ class PesapalTransactionServiceInitializePaymentTest extends TestCase {
             'merchant_reference' => 'mr_serial',
         ]);
 
-        $service->initializePayment(
+        $service->initiatePayment(
             amount: 150.0,
             sender: '+254700000001',
             message: 'SERIAL-XYZ',
@@ -94,7 +94,7 @@ class PesapalTransactionServiceInitializePaymentTest extends TestCase {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Pesapal initialization failed: API error: invalid consumer key');
 
-        $service->initializePayment(
+        $service->initiatePayment(
             amount: 100.0,
             sender: '-',
             message: '1',

--- a/src/backend/app/Services/CashTransactionService.php
+++ b/src/backend/app/Services/CashTransactionService.php
@@ -4,12 +4,15 @@ namespace App\Services;
 
 use App\Models\Transaction\CashTransaction;
 use App\Models\Transaction\Transaction;
-use App\Services\Interfaces\PaymentInitializer;
+use App\Services\Interfaces\PaymentInitiator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
-class CashTransactionService implements PaymentInitializer {
-    public function __construct(private CashTransaction $cashTransaction, private Transaction $transaction) {}
+class CashTransactionService implements PaymentInitiator {
+    public function __construct(
+        private CashTransaction $cashTransaction,
+        private Transaction $transaction,
+    ) {}
 
     public function createTransaction(int $creatorId, float $amount, string $sender, string $message, string $type = Transaction::TYPE_DEFERRED_PAYMENT): Transaction {
         return DB::transaction(function () use ($creatorId, $amount, $sender, $message, $type) {
@@ -35,7 +38,7 @@ class CashTransactionService implements PaymentInitializer {
     /**
      * @return array{transaction: Transaction, provider_data: array<string, mixed>}
      */
-    public function initializePayment(
+    public function initiatePayment(
         float $amount,
         string $sender,
         string $message,

--- a/src/backend/app/Services/Interfaces/PaymentInitiator.php
+++ b/src/backend/app/Services/Interfaces/PaymentInitiator.php
@@ -13,18 +13,26 @@ use App\Models\Transaction\Transaction;
  * opposed to payments the customer initiates externally (e.g. an unsolicited
  * mobile-money transfer that MPM receives as an inbound notification).
  *
- * Such MPM-initiated requests can originate from anywhere inside the system, for
- * example a "request payment" button in MPM, a public-facing payment website,
- * or the agent app. A provider only implements this interface if MPM is able
- * to kick off a transaction with it; inbound-only providers do not.
+ * Such MPM-initiated requests can originate from anywhere inside the system,
+ * for example
+ * - "request payment" button in Sold Appliance view
+ * - public-facing payment website,
+ * - the agent app
  *
- * "Initialize" means creating a provider-specific record (e.g. PaystackTransaction,
- * CashTransaction) and an associated Transaction record in "requested" status.
+ * A provider only implements this interface if MPM is able to initiate a transaction
+ * with it.
  *
- * For redirect-based providers (e.g. Paystack), the returned provider_data
- * contains a redirect_url the client must follow to complete payment.
- * For immediate providers (e.g. cash), provider_data is empty and the
- * transaction is ready for processing right away.
+ * As part of the initiation a provider-specific record (e.g. PaystackTransaction,
+ * CashTransaction) and an associated Transaction record should be created.
+ * The initial records should be in "requested" status.
+ *
+ * Then, the payment provider does it's thing. For example
+ * - For redirect-based providers (e.g. Paystack), the returned provider_data
+ *   contains a redirect_url the client must follow to complete payment.
+ * - For immediate providers (e.g. cash), provider_data is empty and the
+ *   transaction is ready for processing right away.
+ * - Mobile money providers send USSD push to the customer which they have
+ *   to confirm with their mobile money pin
  *
  * Payment validation (device ownership, minimum purchase amounts) is handled
  * separately by ITransactionProvider::validateRequest() and

--- a/src/backend/app/Services/Interfaces/PaymentInitiator.php
+++ b/src/backend/app/Services/Interfaces/PaymentInitiator.php
@@ -9,30 +9,21 @@ use App\Models\Transaction\Transaction;
 /**
  * Contract for payment providers that support MPM-initiated transactions.
  *
- * This covers the flow where MPM requests a payment from the customer, as
- * opposed to payments the customer initiates externally (e.g. an unsolicited
- * mobile-money transfer that MPM receives as an inbound notification).
+ * This is the flow where MPM requests a payment from the customer, as opposed to
+ * payments the customer initiates externally (e.g. an unsolicited mobile-money
+ * transfer that MPM receives as an inbound notification). A provider implements
+ * this interface only if MPM can initiate a transaction with it.
  *
- * Such MPM-initiated requests can originate from anywhere inside the system,
- * for example
- * - "request payment" button in Sold Appliance view
- * - public-facing payment website,
- * - the agent app
+ * Requests to initiate a transaction can originate anywhere in MPM,
+ * e.g. the "request payment" button in the Sold Appliance view, the public payment
+ * website, or the agent app.
  *
- * A provider only implements this interface if MPM is able to initiate a transaction
- * with it.
- *
- * As part of the initiation a provider-specific record (e.g. PaystackTransaction,
- * CashTransaction) and an associated Transaction record should be created.
- * The initial records should be in "requested" status.
- *
- * Then, the payment provider does it's thing. For example
- * - For redirect-based providers (e.g. Paystack), the returned provider_data
- *   contains a redirect_url the client must follow to complete payment.
- * - For immediate providers (e.g. cash), provider_data is empty and the
- *   transaction is ready for processing right away.
- * - Mobile money providers send USSD push to the customer which they have
- *   to confirm with their mobile money pin
+ * Initiating a payment creates a provider-specific record (e.g. PaystackTransaction,
+ * CashTransaction) plus an associated Transaction, both in "requested" status. The
+ * returned provider_data then varies by provider:
+ * - redirect-based (e.g. Paystack): a redirect_url the client follows to complete payment.
+ * - immediate (e.g. cash): empty; the transaction is ready to process right away.
+ * - mobile money: empty; the customer confirms a USSD push with their mobile-money PIN.
  *
  * Payment validation (device ownership, minimum purchase amounts) is handled
  * separately by ITransactionProvider::validateRequest() and

--- a/src/backend/app/Services/Interfaces/PaymentInitiator.php
+++ b/src/backend/app/Services/Interfaces/PaymentInitiator.php
@@ -7,7 +7,16 @@ namespace App\Services\Interfaces;
 use App\Models\Transaction\Transaction;
 
 /**
- * Contract for payment provider initialization.
+ * Contract for payment providers that support MPM-initiated transactions.
+ *
+ * This covers the flow where MPM requests a payment from the customer, as
+ * opposed to payments the customer initiates externally (e.g. an unsolicited
+ * mobile-money transfer that MPM receives as an inbound notification).
+ *
+ * Such MPM-initiated requests can originate from anywhere inside the system, for
+ * example a "request payment" button in MPM, a public-facing payment website,
+ * or the agent app. A provider only implements this interface if MPM is able
+ * to kick off a transaction with it; inbound-only providers do not.
  *
  * "Initialize" means creating a provider-specific record (e.g. PaystackTransaction,
  * CashTransaction) and an associated Transaction record in "requested" status.
@@ -17,15 +26,15 @@ use App\Models\Transaction\Transaction;
  * For immediate providers (e.g. cash), provider_data is empty and the
  * transaction is ready for processing right away.
  *
- * Provider validation (device ownership, minimum purchase amounts) is handled
+ * Payment validation (device ownership, minimum purchase amounts) is handled
  * separately by ITransactionProvider::validateRequest() and
  * AbstractPaymentAggregatorTransactionService::validatePaymentOwner().
  */
-interface PaymentInitializer {
+interface PaymentInitiator {
     /**
      * @return array{transaction: Transaction, provider_data: array<string, mixed>}
      */
-    public function initializePayment(
+    public function initiatePayment(
         float $amount,
         string $sender,
         string $message,

--- a/src/backend/app/Services/PaymentInitiationService.php
+++ b/src/backend/app/Services/PaymentInitiationService.php
@@ -9,16 +9,16 @@ use App\Models\Plugins;
 use App\Models\Transaction\Transaction;
 use App\Plugins\PaystackPaymentProvider\Services\PaystackTransactionService;
 use App\Plugins\PesapalPaymentProvider\Services\PesapalTransactionService;
-use App\Services\Interfaces\PaymentInitializer;
+use App\Services\Interfaces\PaymentInitiator;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Collection;
 
-class PaymentInitializationService {
+class PaymentInitiationService {
     /**
-     * Maps provider IDs to their PaymentInitializer implementation class.
+     * Maps provider IDs to their PaymentInitiator implementation class.
      * When adding a new payment provider plugin, register it here.
      *
-     * @var array<int, class-string<PaymentInitializer>>
+     * @var array<int, class-string<PaymentInitiator>>
      */
     private const PROVIDER_MAP = [
         0 => CashTransactionService::class,
@@ -44,7 +44,7 @@ class PaymentInitializationService {
      *
      * @return array{transaction: Transaction, provider_data: array<string, mixed>}
      */
-    public function initialize(
+    public function initiate(
         int $providerId,
         float $amount,
         string $sender,
@@ -57,9 +57,9 @@ class PaymentInitializationService {
             throw new \InvalidArgumentException("Unsupported payment provider ID: {$providerId}");
         }
 
-        $initializer = $this->container->make(self::PROVIDER_MAP[$providerId]);
+        $initiator = $this->container->make(self::PROVIDER_MAP[$providerId]);
 
-        return $initializer->initializePayment(
+        return $initiator->initiatePayment(
             $amount,
             $sender,
             $message,
@@ -76,7 +76,10 @@ class PaymentInitializationService {
         return $activePlugins->map(function (Plugins $plugin): array {
             $mpmPlugin = $this->mpmPluginService->getById($plugin->mpm_plugin_id);
 
-            return ['id' => $plugin->mpm_plugin_id, 'name' => $mpmPlugin instanceof MpmPlugin ? $mpmPlugin->name : 'Unknown'];
+            return [
+                'id' => $plugin->mpm_plugin_id,
+                'name' => $mpmPlugin instanceof MpmPlugin ? $mpmPlugin->name : 'Unknown',
+            ];
         });
     }
 }

--- a/src/backend/tests/Unit/PaymentInitiationServiceTest.php
+++ b/src/backend/tests/Unit/PaymentInitiationServiceTest.php
@@ -9,14 +9,14 @@ use App\Models\Transaction\Transaction;
 use App\Plugins\PaystackPaymentProvider\Services\PaystackTransactionService;
 use App\Services\CashTransactionService;
 use App\Services\MpmPluginService;
-use App\Services\PaymentInitializationService;
+use App\Services\PaymentInitiationService;
 use App\Services\PluginsService;
 use Illuminate\Contracts\Container\Container;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class PaymentInitializationServiceTest extends TestCase {
-    private PaymentInitializationService $service;
+class PaymentInitiationServiceTest extends TestCase {
+    private PaymentInitiationService $service;
 
     /** @var Container&MockObject */
     private MockObject $container;
@@ -41,7 +41,7 @@ class PaymentInitializationServiceTest extends TestCase {
             [PaystackTransactionService::class, [], $this->paystackService],
         ]);
 
-        $this->service = new PaymentInitializationService(
+        $this->service = new PaymentInitiationService(
             $pluginsService,
             $mpmPluginService,
             $this->container,
@@ -52,7 +52,7 @@ class PaymentInitializationServiceTest extends TestCase {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported payment provider ID: 999');
 
-        $this->service->initialize(
+        $this->service->initiate(
             providerId: 999,
             amount: 100.0,
             sender: '+2340000',
@@ -67,11 +67,11 @@ class PaymentInitializationServiceTest extends TestCase {
 
         $this->cashService
             ->expects($this->once())
-            ->method('initializePayment')
+            ->method('initiatePayment')
             ->with(100.0, '+2340000', '42', 'deferred_payment', 5, null)
             ->willReturn(['transaction' => $transaction, 'provider_data' => []]);
 
-        $result = $this->service->initialize(
+        $result = $this->service->initiate(
             providerId: 0,
             amount: 100.0,
             sender: '+2340000',
@@ -89,7 +89,7 @@ class PaymentInitializationServiceTest extends TestCase {
 
         $this->paystackService
             ->expects($this->once())
-            ->method('initializePayment')
+            ->method('initiatePayment')
             ->with(100.0, '+2340000', '42', 'deferred_payment', 5, null)
             ->willReturn([
                 'transaction' => $transaction,
@@ -99,7 +99,7 @@ class PaymentInitializationServiceTest extends TestCase {
                 ],
             ]);
 
-        $result = $this->service->initialize(
+        $result = $this->service->initiate(
             providerId: MpmPlugin::PAYSTACK_PAYMENT_PROVIDER,
             amount: 100.0,
             sender: '+2340000',
@@ -115,11 +115,11 @@ class PaymentInitializationServiceTest extends TestCase {
     public function testDoesNotCallPaystackServiceForCashProvider(): void {
         $transaction = new Transaction();
 
-        $this->cashService->method('initializePayment')
+        $this->cashService->method('initiatePayment')
             ->willReturn(['transaction' => $transaction, 'provider_data' => []]);
-        $this->paystackService->expects($this->never())->method('initializePayment');
+        $this->paystackService->expects($this->never())->method('initiatePayment');
 
-        $this->service->initialize(
+        $this->service->initiate(
             providerId: 0,
             amount: 50.0,
             sender: '-',
@@ -132,13 +132,13 @@ class PaymentInitializationServiceTest extends TestCase {
     public function testDoesNotCallCashServiceForPaystackProvider(): void {
         $transaction = new Transaction();
 
-        $this->paystackService->method('initializePayment')->willReturn([
+        $this->paystackService->method('initiatePayment')->willReturn([
             'transaction' => $transaction,
             'provider_data' => ['redirect_url' => 'https://paystack.com/pay/x', 'reference' => 'ref_x'],
         ]);
-        $this->cashService->expects($this->never())->method('initializePayment');
+        $this->cashService->expects($this->never())->method('initiatePayment');
 
-        $this->service->initialize(
+        $this->service->initiate(
             providerId: MpmPlugin::PAYSTACK_PAYMENT_PROVIDER,
             amount: 50.0,
             sender: '-',
@@ -153,14 +153,14 @@ class PaymentInitializationServiceTest extends TestCase {
 
         $this->paystackService
             ->expects($this->once())
-            ->method('initializePayment')
+            ->method('initiatePayment')
             ->with(200.0, '+2340000', 'SERIAL-001', 'deferred_payment', 5, 'SERIAL-001')
             ->willReturn([
                 'transaction' => $transaction,
                 'provider_data' => ['redirect_url' => 'https://paystack.com/pay/y', 'reference' => 'ref_y'],
             ]);
 
-        $this->service->initialize(
+        $this->service->initiate(
             providerId: MpmPlugin::PAYSTACK_PAYMENT_PROVIDER,
             amount: 200.0,
             sender: '+2340000',


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Working with Payment Providers I noticed some inconsistencies which attempting to clean up here.

This PR tries to make it a bit more clear what the Payment Initiator contract is meant for. I had problems understanding this at first, hoping the updated PHPDocs documents my learning.

Also, small nit, I'm suggesting to rename the contract to use **Initiate** over **Initialize**, as the contract defines the function to start a payment flow through a payment gateway.

Initialize = set up an object's internal state/config (e.g. "initialize a variable"). It says nothing about starting a process.

Initiate = begin/trigger a process or action. 

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
