### PR TITLE
fix: device unit search should hit the server and not rely only on the first 50 units loaded

### DIFF
--- a/src/backend/app/Http/Controllers/DeviceController.php
+++ b/src/backend/app/Http/Controllers/DeviceController.php
@@ -14,7 +14,7 @@ class DeviceController extends Controller {
 
     public function index(Request $request): ApiResource {
         $limit = $request->integer('per_page', 15);
-        $filters = $request->only(['device_type', 'appliance_id', 'unassigned']);
+        $filters = $request->only(['device_type', 'appliance_id', 'unassigned', 'serial']);
 
         return ApiResource::make($this->deviceService->getAll($limit, $filters));
     }

--- a/src/backend/app/Services/DeviceService.php
+++ b/src/backend/app/Services/DeviceService.php
@@ -74,6 +74,7 @@ class DeviceService implements IBaseService, IAssociative {
         $query = $this->device->newQuery()
             ->with(['person', 'device'])
             ->when($filters['device_type'] ?? null, fn ($q, $type) => $q->where('device_type', $type))
+            ->when($filters['serial'] ?? null, fn ($q, $serial) => $q->where('device_serial', 'LIKE', "%{$serial}%"))
             ->when($filters['appliance_id'] ?? null, fn ($q, $applianceId) => $q->whereHasMorph(
                 'device',
                 [SolarHomeSystem::class, EBike::class],

--- a/src/backend/tests/Feature/DeviceSerialSearchTest.php
+++ b/src/backend/tests/Feature/DeviceSerialSearchTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Device;
+use App\Models\SolarHomeSystem;
+use Database\Factories\ApplianceFactory;
+use Database\Factories\ManufacturerFactory;
+use Tests\CreateEnvironments;
+use Tests\TestCase;
+
+class DeviceSerialSearchTest extends TestCase {
+    use CreateEnvironments;
+
+    public function testDeviceIndexFiltersUnassignedDevicesBySerial(): void {
+        $this->createTestData();
+        $this->createApplianceType();
+        $appliance = ApplianceFactory::new()->create([
+            'appliance_type_id' => $this->applianceType->id,
+        ]);
+
+        $match = $this->createShsDevice('6551180400', $appliance->id);
+        $otherSerial = $this->createShsDevice('6550986800', $appliance->id);
+
+        $response = $this->actingAs($this->user)
+            ->get(sprintf('/api/devices?unassigned=1&appliance_id=%d&serial=11804', $appliance->id));
+
+        $response->assertStatus(200);
+        $serials = collect($response->json('data'))->pluck('device_serial')->all();
+        $this->assertContains($match->device_serial, $serials);
+        $this->assertNotContains($otherSerial->device_serial, $serials);
+    }
+
+    public function testSerialFilterFindsDevicesBeyondTheFirstPage(): void {
+        $this->createTestData();
+        $this->createApplianceType();
+        $appliance = ApplianceFactory::new()->create([
+            'appliance_type_id' => $this->applianceType->id,
+        ]);
+
+        // The serial under test is created first, so it is the oldest record and
+        // would fall outside the default first page once newer devices exist.
+        $target = $this->createShsDevice('6551211200', $appliance->id);
+        foreach (range(1, 60) as $index) {
+            $this->createShsDevice(sprintf('NEWER-%04d', $index), $appliance->id);
+        }
+
+        $response = $this->actingAs($this->user)
+            ->get(sprintf('/api/devices?unassigned=1&appliance_id=%d&per_page=50&serial=6551211200', $appliance->id));
+
+        $response->assertStatus(200);
+        $serials = collect($response->json('data'))->pluck('device_serial')->all();
+        $this->assertContains($target->device_serial, $serials);
+    }
+
+    private function createShsDevice(string $serial, int $applianceId): Device {
+        $manufacturer = ManufacturerFactory::new()->isShsManufacturer()->create();
+        $shs = SolarHomeSystem::query()->create([
+            'serial_number' => $serial,
+            'manufacturer_id' => $manufacturer->id,
+            'appliance_id' => $applianceId,
+        ]);
+
+        return Device::query()->create([
+            'person_id' => null,
+            'device_id' => $shs->id,
+            'device_type' => SolarHomeSystem::RELATION_NAME,
+            'device_serial' => $serial,
+        ]);
+    }
+}

--- a/src/frontend/src/modules/Client/Appliances/SellApplianceModal.vue
+++ b/src/frontend/src/modules/Client/Appliances/SellApplianceModal.vue
@@ -431,7 +431,10 @@
                       />
                     </md-field>
                   </div>
-                  <template v-if="!filteredDeviceSelectionList.length">
+                  <template v-if="isDeviceSearching">
+                    <md-option disabled>Searching…</md-option>
+                  </template>
+                  <template v-else-if="!deviceSelectionList.length">
                     <md-option disabled>
                       <md-tooltip md-direction="top">
                         Consider changing the search term or create a suitable
@@ -442,7 +445,7 @@
                   </template>
                   <template v-else>
                     <md-option
-                      v-for="device in filteredDeviceSelectionList"
+                      v-for="device in deviceSelectionList"
                       :key="device.id"
                       :value="device.serial"
                     >
@@ -635,6 +638,8 @@ import { DeviceService } from "@/services/DeviceService.js"
 import { ICONS, MappingService } from "@/services/MappingService.js"
 import Loader from "@/shared/Loader.vue"
 
+const debounce = require("debounce")
+
 const APPLIANCE_TYPE_SHS_ID = 1
 const APPLIANCE_TYPE_E_BIKE_ID = 2
 export default {
@@ -678,6 +683,7 @@ export default {
       paymentProviders: [],
       paymentProvider: 0,
       deviceSearchTerm: "",
+      isDeviceSearching: false,
     }
   },
   created() {
@@ -986,6 +992,22 @@ export default {
     resetDeviceSearch() {
       this.deviceSearchTerm = ""
     },
+    async loadDevicesForAppliance(serial = null) {
+      this.isDeviceSearching = true
+      const result = await this.deviceService.getAvailableDevicesForAppliance(
+        this.selectedApplianceId,
+        serial,
+      )
+      this.isDeviceSearching = false
+      if (result instanceof ErrorHandler) {
+        this.deviceSelectionList = []
+        return
+      }
+      this.deviceSelectionList = this.deviceService.list.map((device) => ({
+        id: device.id,
+        serial: device.deviceSerial,
+      }))
+    },
   },
   computed: {
     ...mapGetters({
@@ -1001,13 +1023,6 @@ export default {
     },
     showRatesButton() {
       return this.applianceService.appliance.rate > 1
-    },
-    filteredDeviceSelectionList() {
-      const term = this.deviceSearchTerm.trim().toLowerCase()
-      if (!term) return this.deviceSelectionList
-      return this.deviceSelectionList.filter((device) =>
-        device.serial.toLowerCase().includes(term),
-      )
     },
     formattedDeviceLatitude() {
       if (!this.deviceLocation) return ""
@@ -1037,6 +1052,10 @@ export default {
     },
   },
   watch: {
+    deviceSearchTerm: debounce(function () {
+      if (!this.isDeviceSelectionRequired || !this.selectedApplianceId) return
+      this.loadDevicesForAppliance(this.deviceSearchTerm.trim() || null)
+    }, 300),
     async showSellApplianceModal(value) {
       this.internalDialogVisible = value
       if (value) {
@@ -1057,14 +1076,9 @@ export default {
       if (this.isDeviceBindingRequired(appliance)) {
         this.isDeviceSelectionRequired = true
         this.selectedDeviceSerial = null
+        this.deviceSearchTerm = ""
         this.resetDeviceSelectionValidation()
-        await this.deviceService.getAvailableDevicesForAppliance(
-          this.selectedApplianceId,
-        )
-        this.deviceSelectionList = this.deviceService.list.map((device) => ({
-          id: device.id,
-          serial: device.deviceSerial,
-        }))
+        await this.loadDevicesForAppliance()
       } else {
         this.isDeviceSelectionRequired = false
         this.deviceSelectionList = []

--- a/src/frontend/src/services/DeviceService.js
+++ b/src/frontend/src/services/DeviceService.js
@@ -41,12 +41,13 @@ export class DeviceService {
     }
   }
 
-  async getAvailableDevicesForAppliance(applianceId) {
+  async getAvailableDevicesForAppliance(applianceId, serial = null) {
     const params = {
       unassigned: 1,
       appliance_id: applianceId,
       per_page: 50,
     }
+    if (serial) params.serial = serial
     return this.getDevices(params)
   }
 }


### PR DESCRIPTION
Hotfix to update from client side search to server enabled search.

<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
