### PR TITLE
Use better inheritance in PaymentProvider services

### DIFF
--- a/src/backend/app/Models/Transaction/AgentTransaction.php
+++ b/src/backend/app/Models/Transaction/AgentTransaction.php
@@ -3,23 +3,19 @@
 namespace App\Models\Transaction;
 
 use App\Models\Agent;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
  * @property      int                                   $id
  * @property      int                                   $agent_id
  * @property      string                                $mobile_device_id
- * @property      int                                   $status
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
  * @property      string|null                           $manufacturer_transaction_type
  * @property      int|null                              $manufacturer_transaction_id
  * @property-read Agent|null                            $agent
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|null                            $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
@@ -31,13 +27,6 @@ class AgentTransaction extends BasePaymentProviderTransaction {
      */
     public function agent(): BelongsTo {
         return $this->belongsTo(Agent::class);
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public static function getTransactionName(): string {

--- a/src/backend/app/Models/Transaction/BasePaymentProviderTransaction.php
+++ b/src/backend/app/Models/Transaction/BasePaymentProviderTransaction.php
@@ -4,7 +4,9 @@ namespace App\Models\Transaction;
 
 use App\Models\Base\BaseModel;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
@@ -12,8 +14,20 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * Base class for payment provider transaction models.
  *
  * This abstract class provides common relationship methods that are shared across all payment provider transaction implementations.
+ *
+ * @property      int                                   $status
+ * @property-read Collection<int, TransactionConflicts> $conflicts
  */
 abstract class BasePaymentProviderTransaction extends BaseModel {
+    /**
+     * Get the conflicts detected for this transaction.
+     *
+     * @return MorphMany<TransactionConflicts, $this>
+     */
+    public function conflicts(): MorphMany {
+        return $this->morphMany(TransactionConflicts::class, 'transaction');
+    }
+
     /**
      * Get the base transaction relationship.
      *

--- a/src/backend/app/Models/Transaction/CashTransaction.php
+++ b/src/backend/app/Models/Transaction/CashTransaction.php
@@ -3,21 +3,17 @@
 namespace App\Models\Transaction;
 
 use App\Models\User;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
  * @property      int                                   $id
  * @property      int                                   $user_id
- * @property      int                                   $status
  * @property      string|null                           $manufacturer_transaction_type
  * @property      int|null                              $manufacturer_transaction_id
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|null                            $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  * @property-read User|null                             $user
@@ -30,13 +26,6 @@ class CashTransaction extends BasePaymentProviderTransaction {
      */
     public function user(): BelongsTo {
         return $this->belongsTo(User::class);
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public static function getTransactionName(): string {

--- a/src/backend/app/Models/Transaction/ThirdPartyTransaction.php
+++ b/src/backend/app/Models/Transaction/ThirdPartyTransaction.php
@@ -2,33 +2,22 @@
 
 namespace App\Models\Transaction;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
  * @property      int                                   $id
  * @property      string                                $transaction_id
- * @property      int                                   $status
  * @property      string|null                           $description
  * @property      string|null                           $manufacturer_transaction_type
  * @property      int|null                              $manufacturer_transaction_id
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|null                            $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
 class ThirdPartyTransaction extends BasePaymentProviderTransaction {
     public const RELATION_NAME = 'third_party_transaction';
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
-    }
 
     public static function getTransactionName(): string {
         return self::RELATION_NAME;

--- a/src/backend/app/Models/Transaction/Transaction.php
+++ b/src/backend/app/Models/Transaction/Transaction.php
@@ -8,11 +8,6 @@ use App\Models\Device;
 use App\Models\PaymentHistory;
 use App\Models\Sms;
 use App\Models\Token;
-use App\Plugins\MesombPaymentProvider\Models\MesombTransaction;
-use App\Plugins\PaystackPaymentProvider\Models\PaystackTransaction;
-use App\Plugins\SwiftaPaymentProvider\Models\SwiftaTransaction;
-use App\Plugins\WavecomPaymentProvider\Models\WaveComTransaction;
-use App\Plugins\WaveMoneyPaymentProvider\Models\WaveMoneyTransaction;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -33,21 +28,21 @@ use Illuminate\Support\Facades\DB;
  * The `originalTransaction()` method links this system-level transaction to the
  * payment provider-specific transaction.
  *
- * @property      int                                                                                                                                                    $id
- * @property      int                                                                                                                                                    $original_transaction_id
- * @property      string                                                                                                                                                 $original_transaction_type
- * @property      float                                                                                                                                                  $amount
- * @property      string|null                                                                                                                                            $type
- * @property      string                                                                                                                                                 $sender
- * @property      string                                                                                                                                                 $message
- * @property      Carbon|null                                                                                                                                            $created_at
- * @property      Carbon|null                                                                                                                                            $updated_at
- * @property-read AppliancePerson|null                                                                                                                                   $appliance
- * @property-read Device|null                                                                                                                                            $device
- * @property-read AgentTransaction|CashTransaction|ThirdPartyTransaction|MesombTransaction|SwiftaTransaction|WaveComTransaction|WaveMoneyTransaction|PaystackTransaction $originalTransaction
- * @property-read Collection<int, PaymentHistory>                                                                                                                        $paymentHistories
- * @property-read Sms|null                                                                                                                                               $sms
- * @property-read Token|null                                                                                                                                             $token
+ * @property      int                             $id
+ * @property      int                             $original_transaction_id
+ * @property      string                          $original_transaction_type
+ * @property      float                           $amount
+ * @property      string|null                     $type
+ * @property      string                          $sender
+ * @property      string                          $message
+ * @property      Carbon|null                     $created_at
+ * @property      Carbon|null                     $updated_at
+ * @property-read AppliancePerson|null            $appliance
+ * @property-read Device|null                     $device
+ * @property-read BasePaymentProviderTransaction  $originalTransaction
+ * @property-read Collection<int, PaymentHistory> $paymentHistories
+ * @property-read Sms|null                        $sms
+ * @property-read Token|null                      $token
  */
 class Transaction extends BaseModel {
     public const RELATION_NAME = 'transaction';
@@ -61,10 +56,10 @@ class Transaction extends BaseModel {
     /**
      * Get the payment provider-specific transaction linked to this system transaction.
      *
-     * @return MorphTo<AgentTransaction|CashTransaction|ThirdPartyTransaction|MesombTransaction|SwiftaTransaction|WaveComTransaction|WaveMoneyTransaction|PaystackTransaction, $this>
+     * @return MorphTo<BasePaymentProviderTransaction, $this>
      */
     public function originalTransaction(): MorphTo {
-        /** @var MorphTo<AgentTransaction|CashTransaction|ThirdPartyTransaction|MesombTransaction|SwiftaTransaction|WaveComTransaction|WaveMoneyTransaction|PaystackTransaction, $this> $relation */
+        /** @var MorphTo<BasePaymentProviderTransaction, $this> $relation */
         $relation = $this->morphTo();
 
         return $relation;

--- a/src/backend/app/Plugins/MesombPaymentProvider/Models/MesombTransaction.php
+++ b/src/backend/app/Plugins/MesombPaymentProvider/Models/MesombTransaction.php
@@ -4,16 +4,12 @@ namespace App\Plugins\MesombPaymentProvider\Models;
 
 use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Models\Transaction\TransactionConflicts;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
  * @property      int                                   $id
  * @property      string                                $pk
- * @property      int                                   $status
  * @property      string                                $type
  * @property      float                                 $amount
  * @property      float|null                            $fees
@@ -25,20 +21,12 @@ use Illuminate\Support\Carbon;
  * @property      int                                   $direction
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model                                 $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
 class MesombTransaction extends BasePaymentProviderTransaction {
     protected $table = 'mesomb_transactions';
     public const RELATION_NAME = 'mesomb_transactions';
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
-    }
 
     public static function getTransactionName(): string {
         return self::RELATION_NAME;

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Models/PaystackTransaction.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Models/PaystackTransaction.php
@@ -4,10 +4,7 @@ namespace App\Plugins\PaystackPaymentProvider\Models;
 
 use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Models\Transaction\TransactionConflicts;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
@@ -18,7 +15,6 @@ use Illuminate\Support\Carbon;
  * @property      string                                $currency
  * @property      string                                $order_id
  * @property      string                                $reference_id
- * @property      int                                   $status
  * @property      string|null                           $external_transaction_id
  * @property      int                                   $customer_id
  * @property      string|null                           $serial_id
@@ -31,7 +27,6 @@ use Illuminate\Support\Carbon;
  * @property      int                                   $attempts
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|\Eloquent|null                  $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
@@ -151,13 +146,6 @@ class PaystackTransaction extends BasePaymentProviderTransaction {
 
     public function manufacturerTransaction(): MorphTo {
         return $this->morphTo();
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public static function getTransactionName(): string {

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Services/PaystackTransactionService.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Services/PaystackTransactionService.php
@@ -8,25 +8,21 @@ use App\Jobs\ProcessPayment;
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
 use App\Models\SolarHomeSystem;
+use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
 use App\Plugins\PaystackPaymentProvider\Models\PaystackTransaction;
 use App\Plugins\PaystackPaymentProvider\Modules\Api\PaystackApiService;
-use App\Services\AbstractPaymentAggregatorTransactionService;
-use App\Services\DeviceService;
-use App\Services\Interfaces\IBaseService;
-use App\Services\Interfaces\PaymentInitiator;
-use App\Services\PersonService;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Pagination\LengthAwarePaginator;
+use App\Services\AbstractRedirectPaymentInitiatorService;
 use Illuminate\Support\Facades\DB;
 use Ramsey\Uuid\Uuid;
 
 /**
- * @implements IBaseService<PaystackTransaction>
+ * @extends AbstractRedirectPaymentInitiatorService<PaystackTransaction>
  */
-class PaystackTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService, PaymentInitiator {
+class PaystackTransactionService extends AbstractRedirectPaymentInitiatorService {
     public function __construct(
         private Meter $meter,
+        private SolarHomeSystem $solarHomeSystem,
         private Address $address,
         private Transaction $transaction,
         private PaystackTransaction $paystackTransaction,
@@ -34,6 +30,7 @@ class PaystackTransactionService extends AbstractPaymentAggregatorTransactionSer
     ) {
         parent::__construct(
             $this->meter,
+            $this->solarHomeSystem,
             $this->address,
             $this->transaction,
             $this->paystackTransaction
@@ -44,20 +41,17 @@ class PaystackTransactionService extends AbstractPaymentAggregatorTransactionSer
      * @return array<string, mixed>
      */
     public function initializeTransactionData(): array {
-        $orderId = Uuid::uuid4()->toString();
-        $referenceId = Uuid::uuid4()->toString();
-
         return [
-            'order_id' => $orderId,
-            'reference_id' => $referenceId,
-            'serial_id' => $this->getSerialId(),
+            'order_id' => Uuid::uuid4()->toString(),
+            'reference_id' => Uuid::uuid4()->toString(),
+            'serial_id' => $this->meterSerialNumber,
             'status' => PaystackTransaction::STATUS_REQUESTED,
             'currency' => 'NGN',
-            'customer_id' => $this->getCustomerId(),
-            'amount' => $this->getAmount(),
+            'customer_id' => $this->customerId,
+            'amount' => $this->amount,
             'metadata' => [
-                'serial_id' => $this->getSerialId(),
-                'customer_id' => $this->getCustomerId(),
+                'serial_id' => $this->meterSerialNumber,
+                'customer_id' => $this->customerId,
             ],
         ];
     }
@@ -72,24 +66,6 @@ class PaystackTransactionService extends AbstractPaymentAggregatorTransactionSer
 
     public function getByPaystackReference(string $reference): ?PaystackTransaction {
         return $this->paystackTransaction->newQuery()->where('paystack_reference', '=', $reference)->first();
-    }
-
-    /**
-     * @return Collection<int, PaystackTransaction>
-     */
-    public function getByStatus(int $status): Collection {
-        return $this->paystackTransaction->newQuery()->where('status', '=', $status)->get();
-    }
-
-    public function getById(int $id): ?PaystackTransaction {
-        return $this->paystackTransaction->newQuery()->find($id);
-    }
-
-    public function update($paystackTransaction, array $paystackTransactionData): PaystackTransaction {
-        $paystackTransaction->update($paystackTransactionData);
-        $paystackTransaction->fresh();
-
-        return $paystackTransaction;
     }
 
     public function create(array $paystackTransactionData): PaystackTransaction {
@@ -120,26 +96,8 @@ class PaystackTransactionService extends AbstractPaymentAggregatorTransactionSer
         }
     }
 
-    public function delete($paystackTransaction): ?bool {
-        return $paystackTransaction->delete();
-    }
-
-    public function getAll(?int $limit = null): Collection|LengthAwarePaginator {
-        $query = $this->paystackTransaction->newQuery();
-
-        if ($limit) {
-            return $query->paginate($limit);
-        }
-
-        return $this->paystackTransaction->newQuery()->get();
-    }
-
     public function getPaystackTransaction(): PaystackTransaction {
         return $this->getPaymentAggregatorTransaction();
-    }
-
-    public function getSerialId(): ?string {
-        return $this->getMeterSerialNumber();
     }
 
     public function processSuccessfulPayment(int $companyId, PaystackTransaction $transaction): void {
@@ -159,175 +117,28 @@ class PaystackTransactionService extends AbstractPaymentAggregatorTransactionSer
         }
     }
 
+    protected function resolveCurrency(): string {
+        return config('paystack-payment-provider.currency.default', 'NGN');
+    }
+
+    protected function requestedStatus(): int {
+        return PaystackTransaction::STATUS_REQUESTED;
+    }
+
     /**
-     * Create a PaystackTransaction + Transaction and initialize via the Paystack API.
-     * The caller supplies message and type, keeping routing knowledge outside this service.
+     * @param PaystackTransaction $transaction
      *
-     * @return array{transaction: Transaction, provider_data: array<string, mixed>}
+     * @return array<string, mixed>
      */
-    public function initiatePayment(
-        float $amount,
-        string $sender,
-        string $message,
-        string $type,
-        int $customerId,
-        ?string $serialId = null,
-    ): array {
-        $deviceType = null;
-        if ($serialId !== null) {
-            $device = app(DeviceService::class)->getBySerialNumber($serialId);
-            $deviceType = $device?->device_type;
+    protected function submitToProvider(BasePaymentProviderTransaction $transaction, string $sender): array {
+        $result = $this->paystackApiService->initializeTransaction($transaction);
+        if ($result['error']) {
+            throw new \RuntimeException('Paystack initialization failed: '.$result['error']);
         }
 
-        try {
-            // A failed Paystack initialization must not leave orphaned transaction rows behind.
-            DB::connection('tenant')->beginTransaction();
-
-            $paystackTxn = $this->paystackTransaction->newQuery()->create([
-                'amount' => $amount,
-                'currency' => config('paystack-payment-provider.currency.default', 'NGN'),
-                'order_id' => Uuid::uuid4()->toString(),
-                'reference_id' => Uuid::uuid4()->toString(),
-                'status' => PaystackTransaction::STATUS_REQUESTED,
-                'customer_id' => $customerId,
-                'serial_id' => $serialId,
-                'device_type' => $deviceType,
-                'metadata' => ['customer_id' => $customerId, 'serial_id' => $serialId, 'transaction_type' => $type],
-            ]);
-
-            /** @var Transaction $transaction */
-            $transaction = $paystackTxn->transaction()->create([
-                'amount' => $amount,
-                'sender' => $sender,
-                'message' => $message,
-                'type' => $type,
-            ]);
-
-            $result = $this->paystackApiService->initializeTransaction($paystackTxn);
-            if ($result['error']) {
-                throw new \RuntimeException('Paystack initialization failed: '.$result['error']);
-            }
-
-            DB::connection('tenant')->commit();
-
-            return [
-                'transaction' => $transaction,
-                'provider_data' => [
-                    'redirect_url' => $result['redirectionUrl'],
-                    'reference' => $result['reference'],
-                ],
-            ];
-        } catch (\Exception $e) {
-            DB::connection('tenant')->rollBack();
-            throw $e;
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $transactionData
-     */
-    public function createPublicTransaction(array $transactionData): PaystackTransaction {
-        // Create Paystack transaction without customer association
-        $transactionData['status'] = PaystackTransaction::STATUS_REQUESTED;
-        $transactionData['metadata'] = [
-            'serial_id' => $transactionData['serial_id'],
-            'customer_id' => $transactionData['customer_id'],
-            'public_payment' => true,
+        return [
+            'redirect_url' => $result['redirectionUrl'],
+            'reference' => $result['reference'],
         ];
-
-        // Add agent_id to metadata if provided
-        if (isset($transactionData['agent_id']) && $transactionData['agent_id']) {
-            $transactionData['metadata']['agent_id'] = $transactionData['agent_id'];
-        }
-
-        return $this->paystackTransaction->newQuery()->create($transactionData);
-    }
-
-    public function validateMeterSerial(string $serialId): bool {
-        // Check if meter exists and is active
-        $meter = $this->meter->newQuery()
-            ->where('serial_number', $serialId)
-            ->where('in_use', 1)
-            ->first();
-
-        return $meter !== null;
-    }
-
-    public function validateSHSSerial(string $serialId): bool {
-        // Check if SHS exists
-        $shs = app()->make(SolarHomeSystem::class)
-            ->newQuery()
-            ->where('serial_number', $serialId)
-            ->first();
-
-        return $shs !== null;
-    }
-
-    public function validateDeviceSerial(string $serialId, string $deviceType = 'meter'): bool {
-        if ($deviceType === 'shs') {
-            return $this->validateSHSSerial($serialId);
-        }
-
-        return $this->validateMeterSerial($serialId);
-    }
-
-    public function validatePaymentOwner(string $serialId, float $amount): void {
-        // For public payments, we only validate that the meter exists
-        if (!$this->validateMeterSerial($serialId)) {
-            throw new \Exception('Invalid meter serial number');
-        }
-
-        // Additional validation can be added here (e.g., amount limits)
-        if ($amount <= 0) {
-            throw new \Exception('Invalid payment amount');
-        }
-    }
-
-    public function getCustomerIdByMeterSerial(string $serialId): ?int {
-        // Find the meter by serial number and get the associated customer ID
-        $meter = $this->meter->newQuery()
-            ->where('serial_number', $serialId)
-            ->where('in_use', 1)
-            ->first();
-
-        if (!$meter) {
-            return null;
-        }
-
-        // Return the customer ID associated with the meter
-        $person = $meter->device->person->id;
-
-        return $person;
-    }
-
-    public function getCustomerIdBySHSSerial(string $serialId): ?int {
-        // Find SHS by serial number and resolve owning person via device relationship
-        $shs = app()->make(SolarHomeSystem::class)
-            ->newQuery()
-            ->where('serial_number', $serialId)
-            ->first();
-
-        if (!$shs) {
-            return null;
-        }
-
-        $device = $shs->device()->first();
-        if (!$device || !$device->person) {
-            return null;
-        }
-
-        return (int) $device->person->id;
-    }
-
-    public function getCustomerPhoneByCustomerId(int $customerId): ?string {
-        // Get the customer's phone number by customer ID
-        try {
-            $personService = app()->make(PersonService::class);
-            $person = $personService->getById($customerId);
-
-            return (string) $person->addresses->first()->phone;
-        } catch (\Exception) {
-            return null;
-        }
     }
 }

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Models/PesapalTransaction.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Models/PesapalTransaction.php
@@ -4,10 +4,7 @@ namespace App\Plugins\PesapalPaymentProvider\Models;
 
 use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Models\Transaction\TransactionConflicts;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
@@ -18,7 +15,6 @@ use Illuminate\Support\Carbon;
  * @property      string                                $currency
  * @property      string                                $order_id
  * @property      string                                $reference_id
- * @property      int                                   $status
  * @property      string|null                           $external_transaction_id
  * @property      int                                   $customer_id
  * @property      string|null                           $serial_id
@@ -32,7 +28,6 @@ use Illuminate\Support\Carbon;
  * @property      int                                   $attempts
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|\Eloquent|null                  $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
@@ -164,13 +159,6 @@ class PesapalTransaction extends BasePaymentProviderTransaction {
 
     public function manufacturerTransaction(): MorphTo {
         return $this->morphTo();
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public static function getTransactionName(): string {

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Services/PesapalTransactionService.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Services/PesapalTransactionService.php
@@ -8,26 +8,22 @@ use App\Jobs\ProcessPayment;
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
 use App\Models\SolarHomeSystem;
+use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
 use App\Plugins\PesapalPaymentProvider\Models\PesapalTransaction;
 use App\Plugins\PesapalPaymentProvider\Modules\Api\PesapalApiService;
 use App\Plugins\PesapalPaymentProvider\Modules\Api\Resources\GetTransactionStatusResource;
-use App\Services\AbstractPaymentAggregatorTransactionService;
-use App\Services\DeviceService;
-use App\Services\Interfaces\IBaseService;
-use App\Services\Interfaces\PaymentInitiator;
-use App\Services\PersonService;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Pagination\LengthAwarePaginator;
+use App\Services\AbstractRedirectPaymentInitiatorService;
 use Illuminate\Support\Facades\DB;
 use Ramsey\Uuid\Uuid;
 
 /**
- * @implements IBaseService<PesapalTransaction>
+ * @extends AbstractRedirectPaymentInitiatorService<PesapalTransaction>
  */
-class PesapalTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService, PaymentInitiator {
+class PesapalTransactionService extends AbstractRedirectPaymentInitiatorService {
     public function __construct(
         private Meter $meter,
+        private SolarHomeSystem $solarHomeSystem,
         private Address $address,
         private Transaction $transaction,
         private PesapalTransaction $pesapalTransaction,
@@ -36,6 +32,7 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
     ) {
         parent::__construct(
             $this->meter,
+            $this->solarHomeSystem,
             $this->address,
             $this->transaction,
             $this->pesapalTransaction
@@ -46,20 +43,17 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
      * @return array<string, mixed>
      */
     public function initializeTransactionData(): array {
-        $orderId = Uuid::uuid4()->toString();
-        $referenceId = Uuid::uuid4()->toString();
-
         return [
-            'order_id' => $orderId,
-            'reference_id' => $referenceId,
-            'serial_id' => $this->getSerialId(),
+            'order_id' => Uuid::uuid4()->toString(),
+            'reference_id' => Uuid::uuid4()->toString(),
+            'serial_id' => $this->meterSerialNumber,
             'status' => PesapalTransaction::STATUS_REQUESTED,
             'currency' => $this->credentialService->getCredentials()->getCurrency(),
-            'customer_id' => $this->getCustomerId(),
-            'amount' => $this->getAmount(),
+            'customer_id' => $this->customerId,
+            'amount' => $this->amount,
             'metadata' => [
-                'serial_id' => $this->getSerialId(),
-                'customer_id' => $this->getCustomerId(),
+                'serial_id' => $this->meterSerialNumber,
+                'customer_id' => $this->customerId,
             ],
         ];
     }
@@ -82,24 +76,6 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
 
     public function getByReferenceId(string $referenceId): ?PesapalTransaction {
         return $this->pesapalTransaction->newQuery()->where('reference_id', '=', $referenceId)->first();
-    }
-
-    /**
-     * @return Collection<int, PesapalTransaction>
-     */
-    public function getByStatus(int $status): Collection {
-        return $this->pesapalTransaction->newQuery()->where('status', '=', $status)->get();
-    }
-
-    public function getById(int $id): ?PesapalTransaction {
-        return $this->pesapalTransaction->newQuery()->find($id);
-    }
-
-    public function update($pesapalTransaction, array $pesapalTransactionData): PesapalTransaction {
-        $pesapalTransaction->update($pesapalTransactionData);
-        $pesapalTransaction->fresh();
-
-        return $pesapalTransaction;
     }
 
     public function create(array $pesapalTransactionData): PesapalTransaction {
@@ -128,26 +104,8 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
         }
     }
 
-    public function delete($pesapalTransaction): ?bool {
-        return $pesapalTransaction->delete();
-    }
-
-    public function getAll(?int $limit = null): Collection|LengthAwarePaginator {
-        $query = $this->pesapalTransaction->newQuery();
-
-        if ($limit) {
-            return $query->paginate($limit);
-        }
-
-        return $this->pesapalTransaction->newQuery()->get();
-    }
-
     public function getPesapalTransaction(): PesapalTransaction {
         return $this->getPaymentAggregatorTransaction();
-    }
-
-    public function getSerialId(): ?string {
-        return $this->getMeterSerialNumber();
     }
 
     public function processSuccessfulPayment(int $companyId, PesapalTransaction $transaction): void {
@@ -157,6 +115,11 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
         $transaction->save();
     }
 
+    /**
+     * TODO: Unlike PaystackTransactionService::processFailedPayment, this does not mark the
+     * related base Transaction as failed. The two diverged during copy-paste; reconcile once
+     * there is test coverage confirming the intended behaviour.
+     */
     public function processFailedPayment(PesapalTransaction $transaction): void {
         $transaction->setStatus(PesapalTransaction::STATUS_FAILED);
         $transaction->save();
@@ -186,6 +149,34 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
         return $status;
     }
 
+    protected function resolveCurrency(): string {
+        $credential = $this->credentialService->getCredentials();
+
+        return $credential->getCurrency() ?: config('pesapal-payment-provider.currency.default', 'KES');
+    }
+
+    protected function requestedStatus(): int {
+        return PesapalTransaction::STATUS_REQUESTED;
+    }
+
+    /**
+     * @param PesapalTransaction $transaction
+     *
+     * @return array<string, mixed>
+     */
+    protected function submitToProvider(BasePaymentProviderTransaction $transaction, string $sender): array {
+        $result = $this->pesapalApiService->submitOrder($transaction, $sender);
+        if ($result['error']) {
+            throw new \RuntimeException('Pesapal initialization failed: '.$result['error']);
+        }
+
+        return [
+            'redirect_url' => $result['redirect_url'],
+            'order_tracking_id' => $result['order_tracking_id'],
+            'merchant_reference' => $result['merchant_reference'],
+        ];
+    }
+
     private function applyStatusCode(PesapalTransaction $transaction, ?int $statusCode, int $companyId): void {
         switch ($statusCode) {
             case GetTransactionStatusResource::STATUS_COMPLETED:
@@ -199,165 +190,6 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
                 $transaction->setStatus(PesapalTransaction::STATUS_ABANDONED);
                 $transaction->save();
                 break;
-        }
-    }
-
-    /**
-     * @return array{transaction: Transaction, provider_data: array<string, mixed>}
-     */
-    public function initiatePayment(
-        float $amount,
-        string $sender,
-        string $message,
-        string $type,
-        int $customerId,
-        ?string $serialId = null,
-    ): array {
-        $deviceType = null;
-        if ($serialId !== null) {
-            $device = app(DeviceService::class)->getBySerialNumber($serialId);
-            $deviceType = $device?->device_type;
-        }
-
-        $credential = $this->credentialService->getCredentials();
-
-        try {
-            DB::connection('tenant')->beginTransaction();
-
-            $pesapalTxn = $this->pesapalTransaction->newQuery()->create([
-                'amount' => $amount,
-                'currency' => $credential->getCurrency() ?: config('pesapal-payment-provider.currency.default', 'KES'),
-                'order_id' => Uuid::uuid4()->toString(),
-                'reference_id' => Uuid::uuid4()->toString(),
-                'status' => PesapalTransaction::STATUS_REQUESTED,
-                'customer_id' => $customerId,
-                'serial_id' => $serialId,
-                'device_type' => $deviceType,
-                'metadata' => ['customer_id' => $customerId, 'serial_id' => $serialId, 'transaction_type' => $type],
-            ]);
-
-            /** @var Transaction $transaction */
-            $transaction = $pesapalTxn->transaction()->create([
-                'amount' => $amount,
-                'sender' => $sender,
-                'message' => $message,
-                'type' => $type,
-            ]);
-
-            $result = $this->pesapalApiService->submitOrder($pesapalTxn, $sender);
-            if ($result['error']) {
-                throw new \RuntimeException('Pesapal initialization failed: '.$result['error']);
-            }
-
-            DB::connection('tenant')->commit();
-
-            return [
-                'transaction' => $transaction,
-                'provider_data' => [
-                    'redirect_url' => $result['redirect_url'],
-                    'order_tracking_id' => $result['order_tracking_id'],
-                    'merchant_reference' => $result['merchant_reference'],
-                ],
-            ];
-        } catch (\Exception $e) {
-            DB::connection('tenant')->rollBack();
-            throw $e;
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $transactionData
-     */
-    public function createPublicTransaction(array $transactionData): PesapalTransaction {
-        $transactionData['status'] = PesapalTransaction::STATUS_REQUESTED;
-        $transactionData['metadata'] = [
-            'serial_id' => $transactionData['serial_id'],
-            'customer_id' => $transactionData['customer_id'],
-            'public_payment' => true,
-        ];
-
-        if (isset($transactionData['agent_id']) && $transactionData['agent_id']) {
-            $transactionData['metadata']['agent_id'] = $transactionData['agent_id'];
-        }
-
-        return $this->pesapalTransaction->newQuery()->create($transactionData);
-    }
-
-    public function validateMeterSerial(string $serialId): bool {
-        $meter = $this->meter->newQuery()
-            ->where('serial_number', $serialId)
-            ->where('in_use', 1)
-            ->first();
-
-        return $meter !== null;
-    }
-
-    public function validateSHSSerial(string $serialId): bool {
-        $shs = app()->make(SolarHomeSystem::class)
-            ->newQuery()
-            ->where('serial_number', $serialId)
-            ->first();
-
-        return $shs !== null;
-    }
-
-    public function validateDeviceSerial(string $serialId, string $deviceType = 'meter'): bool {
-        if ($deviceType === 'shs') {
-            return $this->validateSHSSerial($serialId);
-        }
-
-        return $this->validateMeterSerial($serialId);
-    }
-
-    public function validatePaymentOwner(string $serialId, float $amount): void {
-        if (!$this->validateMeterSerial($serialId)) {
-            throw new \Exception('Invalid meter serial number');
-        }
-
-        if ($amount <= 0) {
-            throw new \Exception('Invalid payment amount');
-        }
-    }
-
-    public function getCustomerIdByMeterSerial(string $serialId): ?int {
-        $meter = $this->meter->newQuery()
-            ->where('serial_number', $serialId)
-            ->where('in_use', 1)
-            ->first();
-
-        if (!$meter) {
-            return null;
-        }
-
-        return $meter->device->person->id;
-    }
-
-    public function getCustomerIdBySHSSerial(string $serialId): ?int {
-        $shs = app()->make(SolarHomeSystem::class)
-            ->newQuery()
-            ->where('serial_number', $serialId)
-            ->first();
-
-        if (!$shs) {
-            return null;
-        }
-
-        $device = $shs->device()->first();
-        if (!$device || !$device->person) {
-            return null;
-        }
-
-        return (int) $device->person->id;
-    }
-
-    public function getCustomerPhoneByCustomerId(int $customerId): ?string {
-        try {
-            $personService = app()->make(PersonService::class);
-            $person = $personService->getById($customerId);
-
-            return (string) $person->addresses->first()->phone;
-        } catch (\Exception) {
-            return null;
         }
     }
 }

--- a/src/backend/app/Plugins/SmsTransactionParser/Models/SmsTransaction.php
+++ b/src/backend/app/Plugins/SmsTransactionParser/Models/SmsTransaction.php
@@ -6,10 +6,7 @@ namespace App\Plugins\SmsTransactionParser\Models;
 
 use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Models\Transaction\TransactionConflicts;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -20,12 +17,10 @@ use Illuminate\Support\Carbon;
  * @property      string                                $sender_phone
  * @property      string|null                           $device_serial
  * @property      string                                $raw_message
- * @property      int                                   $status
  * @property      string|null                           $manufacturer_transaction_type
  * @property      int|null                              $manufacturer_transaction_id
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|null                            $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
@@ -62,13 +57,6 @@ class SmsTransaction extends BasePaymentProviderTransaction {
 
     public function setStatus(int $status): void {
         $this->status = $status;
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public function getManufacturerTransferType(): ?string {

--- a/src/backend/app/Plugins/SwiftaPaymentProvider/Models/SwiftaTransaction.php
+++ b/src/backend/app/Plugins/SwiftaPaymentProvider/Models/SwiftaTransaction.php
@@ -4,10 +4,7 @@ namespace App\Plugins\SwiftaPaymentProvider\Models;
 
 use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Models\Transaction\TransactionConflicts;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -15,13 +12,11 @@ use Illuminate\Support\Carbon;
  * @property      string|null                           $transaction_reference
  * @property      string|null                           $manufacturer_transaction_type
  * @property      int|null                              $manufacturer_transaction_id
- * @property      int                                   $status
  * @property      float                                 $amount
  * @property      string                                $cipher
  * @property      string                                $timestamp
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|null                            $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
@@ -36,13 +31,6 @@ class SwiftaTransaction extends BasePaymentProviderTransaction {
 
     public function getAmount(): float {
         return $this->amount;
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public static function getTransactionName(): string {

--- a/src/backend/app/Plugins/SwiftaPaymentProvider/Services/SwiftaTransactionService.php
+++ b/src/backend/app/Plugins/SwiftaPaymentProvider/Services/SwiftaTransactionService.php
@@ -4,30 +4,31 @@ namespace App\Plugins\SwiftaPaymentProvider\Services;
 
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
+use App\Models\SolarHomeSystem;
 use App\Models\Transaction\Transaction;
 use App\Models\Transaction\TransactionConflicts;
 use App\Plugins\SwiftaPaymentProvider\Models\SwiftaTransaction;
-use App\Plugins\WavecomPaymentProvider\Models\WaveComTransaction;
-use App\Plugins\WaveMoneyPaymentProvider\Models\WaveMoneyTransaction;
 use App\Services\AbstractPaymentAggregatorTransactionService;
 use App\Services\Interfaces\IBaseService;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Log;
 
 /**
+ * @extends AbstractPaymentAggregatorTransactionService<SwiftaTransaction>
+ *
  * @implements IBaseService<SwiftaTransaction>
  */
 class SwiftaTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService {
     public function __construct(
         private Meter $meter,
+        private SolarHomeSystem $solarHomeSystem,
         private Address $address,
         private Transaction $transaction,
         private SwiftaTransaction $swiftaTransaction,
     ) {
         parent::__construct(
             $this->meter,
+            $this->solarHomeSystem,
             $this->address,
             $this->transaction,
             $this->swiftaTransaction
@@ -62,7 +63,7 @@ class SwiftaTransactionService extends AbstractPaymentAggregatorTransactionServi
         });
     }
 
-    public function getSwiftaTransaction(): SwiftaTransaction|WaveMoneyTransaction|WaveComTransaction {
+    public function getSwiftaTransaction(): SwiftaTransaction {
         return $this->getPaymentAggregatorTransaction();
     }
 
@@ -82,30 +83,5 @@ class SwiftaTransactionService extends AbstractPaymentAggregatorTransactionServi
 
     public function getById(?int $id): SwiftaTransaction {
         return $this->swiftaTransaction->newQuery()->find($id);
-    }
-
-    public function update($swiftaTransaction, $swiftaTransactionData): SwiftaTransaction {
-        $swiftaTransaction->update($swiftaTransactionData);
-        $swiftaTransaction->fresh();
-
-        return $swiftaTransaction;
-    }
-
-    public function create(array $swiftaTransactionData): SwiftaTransaction {
-        return $this->swiftaTransaction->newQuery()->create($swiftaTransactionData);
-    }
-
-    public function delete($swiftaTransaction): ?bool {
-        return $swiftaTransaction->delete();
-    }
-
-    public function getAll(?int $limit = null): Collection|LengthAwarePaginator {
-        $query = $this->swiftaTransaction->newQuery();
-
-        if ($limit) {
-            return $query->paginate($limit);
-        }
-
-        return $this->swiftaTransaction->newQuery()->get();
     }
 }

--- a/src/backend/app/Plugins/WaveMoneyPaymentProvider/Models/WaveMoneyTransaction.php
+++ b/src/backend/app/Plugins/WaveMoneyPaymentProvider/Models/WaveMoneyTransaction.php
@@ -4,15 +4,11 @@ namespace App\Plugins\WaveMoneyPaymentProvider\Models;
 
 use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Models\Transaction\TransactionConflicts;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
  * @property      int                                   $id
- * @property      int                                   $status
  * @property      float                                 $amount
  * @property      string                                $order_id
  * @property      string                                $reference_id
@@ -25,7 +21,6 @@ use Illuminate\Support\Carbon;
  * @property      Carbon|null                           $updated_at
  * @property      string|null                           $manufacturer_transaction_type
  * @property      int|null                              $manufacturer_transaction_id
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|null                            $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
@@ -86,13 +81,6 @@ class WaveMoneyTransaction extends BasePaymentProviderTransaction {
 
     public function setAmount(int $amount): void {
         $this->amount = $amount;
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public static function getTransactionName(): string {

--- a/src/backend/app/Plugins/WaveMoneyPaymentProvider/Modules/Transaction/WaveMoneyTransactionService.php
+++ b/src/backend/app/Plugins/WaveMoneyPaymentProvider/Modules/Transaction/WaveMoneyTransactionService.php
@@ -6,28 +6,29 @@ namespace App\Plugins\WaveMoneyPaymentProvider\Modules\Transaction;
 
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
+use App\Models\SolarHomeSystem;
 use App\Models\Transaction\Transaction;
-use App\Plugins\SwiftaPaymentProvider\Models\SwiftaTransaction;
-use App\Plugins\WavecomPaymentProvider\Models\WaveComTransaction;
 use App\Plugins\WaveMoneyPaymentProvider\Models\WaveMoneyTransaction;
 use App\Services\AbstractPaymentAggregatorTransactionService;
 use App\Services\Interfaces\IBaseService;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Ramsey\Uuid\Uuid;
 
 /**
+ * @extends AbstractPaymentAggregatorTransactionService<WaveMoneyTransaction>
+ *
  * @implements IBaseService<WaveMoneyTransaction>
  */
 class WaveMoneyTransactionService extends AbstractPaymentAggregatorTransactionService implements IBaseService {
     public function __construct(
         private Meter $meter,
+        private SolarHomeSystem $solarHomeSystem,
         private Address $address,
         private Transaction $transaction,
         private WaveMoneyTransaction $waveMoneyTransaction,
     ) {
         parent::__construct(
             $this->meter,
+            $this->solarHomeSystem,
             $this->address,
             $this->transaction,
             $this->waveMoneyTransaction
@@ -52,11 +53,11 @@ class WaveMoneyTransactionService extends AbstractPaymentAggregatorTransactionSe
         return [
             'order_id' => $orderId,
             'reference_id' => $referenceId,
-            'meter_serial' => $this->getMeterSerialNumber(),
+            'meter_serial' => $this->meterSerialNumber,
             'status' => WaveMoneyTransaction::STATUS_REQUESTED,
             'currency' => 'MMK',
-            'customer_id' => $this->getCustomerId(),
-            'amount' => $this->getAmount(),
+            'customer_id' => $this->customerId,
+            'amount' => $this->amount,
         ];
     }
 
@@ -70,44 +71,15 @@ class WaveMoneyTransactionService extends AbstractPaymentAggregatorTransactionSe
             ->firstOrFail();
     }
 
-    /**
-     * @return Collection<int, WaveMoneyTransaction>
-     */
-    public function getByStatus(int $status): Collection {
-        return $this->waveMoneyTransaction->newQuery()->where('status', '=', $status)
-            ->get();
-    }
-
     public function getById(int $id): WaveMoneyTransaction {
         return $this->waveMoneyTransaction->newQuery()->findOrFail($id);
-    }
-
-    public function update($waveMoneyTransaction, array $waveMoneyTransactionData): WaveMoneyTransaction {
-        $waveMoneyTransaction->update($waveMoneyTransactionData);
-        $waveMoneyTransaction->fresh();
-
-        return $waveMoneyTransaction;
     }
 
     public function create($waveMoneyTransactionData): WaveMoneyTransaction {
         return $this->waveMoneyTransaction->newQuery()->create($waveMoneyTransactionData);
     }
 
-    public function delete($waveMoneyTransaction): ?bool {
-        return $waveMoneyTransaction->delete();
-    }
-
-    public function getAll(?int $limit = null): Collection|LengthAwarePaginator {
-        $query = $this->waveMoneyTransaction->newQuery();
-
-        if ($limit) {
-            return $query->paginate($limit);
-        }
-
-        return $this->waveMoneyTransaction->newQuery()->get();
-    }
-
-    public function getWaveMoneyTransaction(): SwiftaTransaction|WaveMoneyTransaction|WaveComTransaction {
+    public function getWaveMoneyTransaction(): WaveMoneyTransaction {
         return $this->getPaymentAggregatorTransaction();
     }
 }

--- a/src/backend/app/Plugins/WavecomPaymentProvider/Models/WaveComTransaction.php
+++ b/src/backend/app/Plugins/WavecomPaymentProvider/Models/WaveComTransaction.php
@@ -6,10 +6,7 @@ namespace App\Plugins\WavecomPaymentProvider\Models;
 
 use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Models\Transaction\TransactionConflicts;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -18,12 +15,10 @@ use Illuminate\Support\Carbon;
  * @property      string                                $sender
  * @property      string                                $message
  * @property      int                                   $amount
- * @property      int                                   $status
  * @property      Carbon|null                           $created_at
  * @property      Carbon|null                           $updated_at
  * @property      string|null                           $manufacturer_transaction_type
  * @property      int|null                              $manufacturer_transaction_id
- * @property-read Collection<int, TransactionConflicts> $conflicts
  * @property-read Model|null                            $manufacturerTransaction
  * @property-read Transaction|null                      $transaction
  */
@@ -63,13 +58,6 @@ class WaveComTransaction extends BasePaymentProviderTransaction {
 
     public function setAmount(int $amount): void {
         $this->amount = $amount;
-    }
-
-    /**
-     * @return MorphMany<TransactionConflicts, $this>
-     */
-    public function conflicts(): MorphMany {
-        return $this->morphMany(TransactionConflicts::class, 'transaction');
     }
 
     public function getManufacturerTransferType(): ?string {

--- a/src/backend/app/Plugins/WavecomPaymentProvider/Services/TransactionService.php
+++ b/src/backend/app/Plugins/WavecomPaymentProvider/Services/TransactionService.php
@@ -16,6 +16,15 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use ParseCsv\Csv;
 
+/**
+ * TODO: This extends AbstractPaymentAggregatorTransactionService but never calls the parent
+ * constructor and only uses CSV import logic of its own. WaveComTransactionProvider::saveTransaction
+ * delegates to the inherited saveTransaction(), which would operate on uninitialised parent state,
+ * so that path is effectively dead. The inheritance should be removed once there is test coverage
+ * confirming the inbound provider flow is unused for Wavecom.
+ *
+ * @extends AbstractPaymentAggregatorTransactionService<WaveComTransaction>
+ */
 class TransactionService extends AbstractPaymentAggregatorTransactionService {
     public function __construct(private Csv $csv) {}
 

--- a/src/backend/app/Services/AbstractPaymentAggregatorTransactionService.php
+++ b/src/backend/app/Services/AbstractPaymentAggregatorTransactionService.php
@@ -8,17 +8,25 @@ use App\Exceptions\TransactionIsInvalidForProcessingIncomingRequestException;
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
 use App\Models\Person\Person;
+use App\Models\SolarHomeSystem;
+use App\Models\Transaction\BasePaymentProviderTransaction;
 use App\Models\Transaction\Transaction;
-use App\Plugins\PaystackPaymentProvider\Models\PaystackTransaction;
-use App\Plugins\PesapalPaymentProvider\Models\PesapalTransaction;
-use App\Plugins\SmsTransactionParser\Models\SmsTransaction;
 use App\Plugins\SteamaMeter\Exceptions\ModelNotFoundException;
-use App\Plugins\SwiftaPaymentProvider\Models\SwiftaTransaction;
-use App\Plugins\WavecomPaymentProvider\Models\WaveComTransaction;
-use App\Plugins\WaveMoneyPaymentProvider\Models\WaveMoneyTransaction;
+use App\Services\Interfaces\IBaseService;
+use App\Traits\HasCrudOperations;
 use App\Utils\MinimumPurchaseAmountValidator;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 
-abstract class AbstractPaymentAggregatorTransactionService {
+/**
+ * @template T of BasePaymentProviderTransaction
+ *
+ * @implements IBaseService<T>
+ */
+abstract class AbstractPaymentAggregatorTransactionService implements IBaseService {
+    /** @use HasCrudOperations<T> */
+    use HasCrudOperations;
+
     private const MINIMUM_TRANSACTION_AMOUNT = 0;
     protected string $payerPhoneNumber;
     protected string $meterSerialNumber;
@@ -28,12 +36,20 @@ abstract class AbstractPaymentAggregatorTransactionService {
 
     public function __construct(
         private Meter $meter,
+        private SolarHomeSystem $solarHomeSystem,
         private Address $address,
         private Transaction $transaction,
-        private SwiftaTransaction|WaveMoneyTransaction|WaveComTransaction|PaystackTransaction|PesapalTransaction|SmsTransaction $paymentAggregatorTransaction,
+        private BasePaymentProviderTransaction $paymentAggregatorTransaction,
     ) {}
 
-    public function validatePaymentOwner(string $meterSerialNumber, float $amount): void {
+    /**
+     * @return T
+     */
+    protected function crudModel(): Model {
+        return $this->paymentAggregatorTransaction;
+    }
+
+    public function validateMeterPayment(string $meterSerialNumber, float $amount): void {
         if (!($meter = $this->meter->findBySerialNumber($meterSerialNumber)) instanceof Meter) {
             throw new ModelNotFoundException('Meter not found with serial number you entered');
         }
@@ -55,6 +71,85 @@ abstract class AbstractPaymentAggregatorTransactionService {
             $this->payerPhoneNumber = $this->getTransactionSender($meterSerialNumber);
         } catch (\Exception $exception) {
             throw new \Exception($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+
+    public function validatePaymentOwner(string $serialId, float $amount): void {
+        if (!$this->validateMeterSerial($serialId)) {
+            throw new \Exception('Invalid meter serial number');
+        }
+
+        $this->validateMeterPayment($serialId, $amount);
+
+        if ($amount <= 0) {
+            throw new \Exception('Invalid payment amount');
+        }
+    }
+
+    public function validateMeterSerial(string $serialId): bool {
+        $meter = $this->meter->newQuery()
+            ->where('serial_number', $serialId)
+            ->where('in_use', 1)
+            ->first();
+
+        return $meter !== null;
+    }
+
+    public function validateSHSSerial(string $serialId): bool {
+        $shs = $this->solarHomeSystem->newQuery()
+            ->where('serial_number', $serialId)
+            ->first();
+
+        return $shs !== null;
+    }
+
+    public function validateDeviceSerial(string $serialId, string $deviceType = 'meter'): bool {
+        if ($deviceType === 'shs') {
+            return $this->validateSHSSerial($serialId);
+        }
+
+        return $this->validateMeterSerial($serialId);
+    }
+
+    public function getCustomerIdByMeterSerial(string $serialId): ?int {
+        $meter = $this->meter->newQuery()
+            ->where('serial_number', $serialId)
+            ->where('in_use', 1)
+            ->first();
+
+        if (!$meter) {
+            return null;
+        }
+
+        return $meter->device->person->id;
+    }
+
+    public function getCustomerIdBySHSSerial(string $serialId): ?int {
+        $shs = app()->make(SolarHomeSystem::class)
+            ->newQuery()
+            ->where('serial_number', $serialId)
+            ->first();
+
+        if (!$shs) {
+            return null;
+        }
+
+        $device = $shs->device()->first();
+        if (!$device || !$device->person) {
+            return null;
+        }
+
+        return (int) $device->person->id;
+    }
+
+    public function getCustomerPhoneByCustomerId(int $customerId): ?string {
+        try {
+            $personService = app()->make(PersonService::class);
+            $person = $personService->getById($customerId);
+
+            return (string) $person->addresses->first()->phone;
+        } catch (\Exception) {
+            return null;
         }
     }
 
@@ -96,7 +191,7 @@ abstract class AbstractPaymentAggregatorTransactionService {
         $validator = resolve(MinimumPurchaseAmountValidator::class);
 
         try {
-            if (!$validator->validate($transactionData, $this->getMinimumPurchaseAmount())) {
+            if (!$validator->validate($transactionData, $this->minimumPurchaseAmount)) {
                 throw new TransactionAmountNotEnoughException('Transaction amount is not enough');
             }
         } catch (TransactionAmountNotEnoughException $e) {
@@ -131,23 +226,10 @@ abstract class AbstractPaymentAggregatorTransactionService {
         }
     }
 
-    public function getCustomerId(): int {
-        return $this->customerId;
-    }
-
-    public function getMeterSerialNumber(): string {
-        return $this->meterSerialNumber;
-    }
-
-    public function getAmount(): float {
-        return $this->amount;
-    }
-
-    public function getMinimumPurchaseAmount(): float {
-        return $this->minimumPurchaseAmount;
-    }
-
-    public function getPaymentAggregatorTransaction(): SwiftaTransaction|WaveMoneyTransaction|WaveComTransaction|PaystackTransaction|PesapalTransaction|SmsTransaction {
+    /**
+     * @return T
+     */
+    public function getPaymentAggregatorTransaction(): BasePaymentProviderTransaction {
         return $this->paymentAggregatorTransaction;
     }
 }

--- a/src/backend/app/Services/AbstractRedirectPaymentInitiatorService.php
+++ b/src/backend/app/Services/AbstractRedirectPaymentInitiatorService.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\SolarHomeSystem;
+use App\Models\Transaction\BasePaymentProviderTransaction;
+use App\Models\Transaction\Transaction;
+use App\Services\Interfaces\PaymentInitiator;
+use Illuminate\Support\Facades\DB;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Shared behaviour for redirect-based payment providers (e.g. Paystack, PesaPal)
+ * where MPM creates a provider transaction and hands the customer a redirect URL
+ * to complete payment on the provider's hosted page.
+ *
+ * Providers only differ in their currency source, status constants and the API
+ * call plus the shape of the redirect data they return, which are supplied by the
+ * abstract hooks below.
+ *
+ * @template T of BasePaymentProviderTransaction
+ *
+ * @extends AbstractPaymentAggregatorTransactionService<T>
+ */
+abstract class AbstractRedirectPaymentInitiatorService extends AbstractPaymentAggregatorTransactionService implements PaymentInitiator {
+    /**
+     * Currency to record on a newly created provider transaction.
+     */
+    abstract protected function resolveCurrency(): string;
+
+    /**
+     * Status value representing a freshly requested provider transaction.
+     */
+    abstract protected function requestedStatus(): int;
+
+    /**
+     * Submit the created provider transaction to the remote gateway.
+     *
+     * Must throw when the gateway rejects the request, otherwise return the
+     * provider-specific redirect data exposed to the caller as provider_data.
+     *
+     * @return array<string, mixed>
+     */
+    abstract protected function submitToProvider(BasePaymentProviderTransaction $transaction, string $sender): array;
+
+    /**
+     * @return array{transaction: Transaction, provider_data: array<string, mixed>}
+     */
+    public function initiatePayment(
+        float $amount,
+        string $sender,
+        string $message,
+        string $type,
+        int $customerId,
+        ?string $serialId = null,
+    ): array {
+        $deviceType = null;
+        if ($serialId !== null) {
+            $device = app(DeviceService::class)->getBySerialNumber($serialId);
+            $deviceType = $device?->device_type;
+        }
+
+        try {
+            // A failed gateway initiation must not leave orphaned transaction rows behind.
+            DB::connection('tenant')->beginTransaction();
+
+            $aggregatorTransaction = $this->getPaymentAggregatorTransaction()->newQuery()->create([
+                'amount' => $amount,
+                'currency' => $this->resolveCurrency(),
+                'order_id' => Uuid::uuid4()->toString(),
+                'reference_id' => Uuid::uuid4()->toString(),
+                'status' => $this->requestedStatus(),
+                'customer_id' => $customerId,
+                'serial_id' => $serialId,
+                'device_type' => $deviceType,
+                'metadata' => ['customer_id' => $customerId, 'serial_id' => $serialId, 'transaction_type' => $type],
+            ]);
+
+            /** @var Transaction $transaction */
+            $transaction = $aggregatorTransaction->transaction()->create([
+                'amount' => $amount,
+                'sender' => $sender,
+                'message' => $message,
+                'type' => $type,
+            ]);
+
+            $providerData = $this->submitToProvider($aggregatorTransaction, $sender);
+
+            DB::connection('tenant')->commit();
+
+            return [
+                'transaction' => $transaction,
+                'provider_data' => $providerData,
+            ];
+        } catch (\Exception $e) {
+            DB::connection('tenant')->rollBack();
+            throw $e;
+        }
+    }
+}

--- a/src/backend/app/Traits/HasCrudOperations.php
+++ b/src/backend/app/Traits/HasCrudOperations.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+/**
+ * Default CRUD implementations for services satisfying App\Services\Interfaces\IBaseService.
+ *
+ * Consuming classes point the trait at the entity to operate on via crudModel().
+ *
+ * @template T of Model
+ */
+trait HasCrudOperations {
+    /**
+     * Returns the model instance the CRUD operations run against.
+     *
+     * Implement this in the consuming service to return its own (usually
+     * constructor-promoted) model property, e.g. `return $this->city;`. This is
+     * the single place that binds the trait to a concrete model, which lets the
+     * generic T resolve to that model in every method below.
+     *
+     * @return T
+     */
+    abstract protected function crudModel(): Model;
+
+    /**
+     * @return T|null
+     */
+    public function getById(int $id): ?Model {
+        return $this->crudModel()->newQuery()->find($id);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return T
+     */
+    public function create(array $data): Model {
+        return $this->crudModel()->newQuery()->create($data);
+    }
+
+    /**
+     * @param T                    $model
+     * @param array<string, mixed> $data
+     *
+     * @return T
+     */
+    public function update(Model $model, array $data): Model {
+        $model->update($data);
+        $model->fresh();
+
+        return $model;
+    }
+
+    /**
+     * @param T $model
+     */
+    public function delete(Model $model): ?bool {
+        return $model->delete();
+    }
+
+    /**
+     * @return Collection<int, T>|LengthAwarePaginator<int, T>
+     */
+    public function getAll(?int $limit = null): Collection|LengthAwarePaginator {
+        $query = $this->crudModel()->newQuery();
+
+        if ($limit) {
+            /** @var LengthAwarePaginator<int, T> $paginated */
+            $paginated = $query->paginate($limit);
+
+            return $paginated;
+        }
+
+        /** @var Collection<int, T> $models */
+        $models = $query->get();
+
+        return $models;
+    }
+}


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Another round of refactoring and improvements that will (hopefully) make working with PaymentProvider plugins a bit easier.

- Better utilize `BasePaymentProviderTransaction.php` and templating to avoid repetition amongst implementations.
- Introduce a `HasCruidOperations` trait. For now, we only use it in Payment Providers but can add this to others later
- Moved validation logic into `AbstractPaymentAggregatorTransactionService.php`

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
