### PR TITLE
Add Test suite safeguard :robot:

### DIFF
--- a/src/backend/phpunit.xml
+++ b/src/backend/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
-  bootstrap="vendor/autoload.php"
+  bootstrap="tests/bootstrap.php"
   colors="true"
   backupGlobals="false"
   processIsolation="false"

--- a/src/backend/tests/bootstrap.php
+++ b/src/backend/tests/bootstrap.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 
@@ -15,8 +16,7 @@ require __DIR__.'/../vendor/autoload.php';
 |
 | Abort otherwise to prevent it running against a development or live database.
 */
-
-/** @var Illuminate\Foundation\Application $app */
+/** @var Application $app */
 $app = require __DIR__.'/../bootstrap/app.php';
 $app->bootstrapWith([
     LoadEnvironmentVariables::class,

--- a/src/backend/tests/bootstrap.php
+++ b/src/backend/tests/bootstrap.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+
+require __DIR__.'/../vendor/autoload.php';
+
+/*
+| Running the test suite might be destructive.
+| It spins tenant databases up and down as part of the testing procedure.
+| Using this bootstrap file as a safeguard to make sure the test suite
+| only ever touches the dedicated testing database.
+|
+| Abort otherwise to prevent it running against a development or live database.
+*/
+
+/** @var Illuminate\Foundation\Application $app */
+$app = require __DIR__.'/../bootstrap/app.php';
+$app->bootstrapWith([
+    LoadEnvironmentVariables::class,
+    LoadConfiguration::class,
+]);
+
+$requiredDatabase = 'mpm_testing';
+
+$connection = (string) config('database.default');
+$database = (string) config("database.connections.{$connection}.database");
+
+if ($database !== $requiredDatabase) {
+    $host = (string) config("database.connections.{$connection}.host");
+    $port = (string) config("database.connections.{$connection}.port");
+
+    fwrite(STDERR, implode("\n", [
+        '',
+        str_repeat('=', 80),
+        'ABORTING TEST RUN — not connected to a dedicated testing database.',
+        '',
+        sprintf('  connection : %s', $connection),
+        sprintf('  database   : %s @ %s:%s', $database, $host, $port),
+        '',
+        sprintf('The database name must be exactly "%s". Run the suite from', $requiredDatabase),
+        'the HOST so .env.testing is used:  cd src/backend && php artisan test',
+        '',
+        'Do NOT run it inside an application Docker container: its DB_* environment',
+        'variables might point to an actual databases and override .env.testing.',
+        str_repeat('=', 80),
+        '',
+    ])."\n");
+
+    exit(1);
+}


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made


Running the test suite might be destructive.
It spins tenant databases up and down as part of the testing procedure.

Under normal circumstances this shouldn't be a problem. But can be problematic if someone (or something in case of agentic development flows) runs this **inside** a Production or Development Docker container.

Using this bootstrap file as a safeguard to make sure the test suite
only ever touches the dedicated testing database.

Abort otherwise to prevent it running against a development or live database.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
