### PR TITLE
The leftover `Scribe` doc tags

### DIFF
--- a/src/backend/app/Http/Controllers/AgentAssignedApplianceWebController.php
+++ b/src/backend/app/Http/Controllers/AgentAssignedApplianceWebController.php
@@ -13,12 +13,7 @@ class AgentAssignedApplianceWebController extends Controller {
     ) {}
 
     /**
-     * Store a newly created resource in storage.
-     *
-     * @bodyParam agent_id integer required
-     * @bodyParam user_id integer required
-     * @bodyParam appliance_type_id integer required
-     * @bodyParam cost integer required
+     * Assign an appliance to an agent.
      *
      * @return ApiResource
      */
@@ -34,7 +29,7 @@ class AgentAssignedApplianceWebController extends Controller {
     }
 
     /**
-     * List for Web interface.
+     * List appliances assigned to an agent.
      *
      * @param int $agentId
      *

--- a/src/backend/app/Http/Controllers/AgentAssignedAppliancesController.php
+++ b/src/backend/app/Http/Controllers/AgentAssignedAppliancesController.php
@@ -5,12 +5,10 @@ namespace App\Http\Controllers;
 use App\Http\Resources\ApiResource;
 use App\Services\AgentAssignedApplianceService;
 use App\Services\AgentService;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\Request;
 
-/**
- * @group   Agent-Appliances
- * Class AgentAssignedApplianceController
- */
+#[Group('AgentApp', weight: 21)]
 class AgentAssignedAppliancesController extends Controller {
     public function __construct(
         private AgentAssignedApplianceService $agentAssignedApplianceService,
@@ -18,7 +16,7 @@ class AgentAssignedAppliancesController extends Controller {
     ) {}
 
     /**
-     * List for Android-APP.
+     * List appliances assigned to the authenticated agent.
      *
      * @return ApiResource
      */

--- a/src/backend/app/Http/Controllers/AgentAuthController.php
+++ b/src/backend/app/Http/Controllers/AgentAuthController.php
@@ -38,9 +38,6 @@ class AgentAuthController extends Controller {
      * Agent login.
      *
      * Login a user of the Agent App and get JWT token via given credentials.
-     *
-     * @bodyParam email string required
-     * @bodyParam password string required
      */
     #[BodyParameter('email', type: 'string', format: 'email', example: DemoCompany::DEMO_COMPANY_AGENT_EMAIL)]
     #[BodyParameter('password', type: 'string', format: 'password', example: DemoCompany::DEMO_COMPANY_PASSWORD)]

--- a/src/backend/app/Http/Controllers/AgentMeterController.php
+++ b/src/backend/app/Http/Controllers/AgentMeterController.php
@@ -4,11 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\ApiResource;
 use App\Services\MeterService;
+use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\Request;
 
-/**
- * @group   Agent-Meters
- */
+#[Group('AgentApp', weight: 21)]
 class AgentMeterController extends Controller {
     public function __construct(
         private MeterService $meterService,
@@ -16,9 +15,6 @@ class AgentMeterController extends Controller {
 
     /**
      * List un-assigned meters for the field agent.
-     *
-     * @queryParam manufacturer_id int
-     * @queryParam meter_type_id int
      */
     public function index(Request $request): ApiResource {
         $manufacturerId = $request->integer('manufacturer_id') ?: null;

--- a/src/backend/app/Http/Controllers/AgentTransactionsController.php
+++ b/src/backend/app/Http/Controllers/AgentTransactionsController.php
@@ -30,7 +30,9 @@ class AgentTransactionsController extends Controller {
     }
 
     /**
-     * Return the token generated for one of the agent's transactions, if any.
+     * Get the token of an agent transaction.
+     *
+     * Returns the token generated for one of the agent's transactions, if any.
      * Token generation is asynchronous (queued in ProcessPayment), so the
      * field app polls this endpoint after a successful POST until the token
      * appears or it gives up.

--- a/src/backend/app/Http/Controllers/MeterConsumptionController.php
+++ b/src/backend/app/Http/Controllers/MeterConsumptionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Resources\ApiResource;
 use App\Services\MeterConsumptionService;
 use App\Services\MeterService;
+use Dedoc\Scramble\Attributes\PathParameter;
 
 class MeterConsumptionController extends Controller {
     public function __construct(
@@ -13,14 +14,13 @@ class MeterConsumptionController extends Controller {
     ) {}
 
     /**
-     * Consumption List
+     * List meter consumptions.
+     *
      * If the meter has the ability to send data to your server. That is the endpoint where you get the
      * meter readings ( used energy, credit on meter etc.).
-     *
-     * @urlParam     serialNumber
-     * @urlParam     start YYYY-mm-dd format
-     * @urlParam     end YYYY-mm-dd format
      */
+    #[PathParameter('start', description: 'Start date in YYYY-mm-dd format.', format: 'date')]
+    #[PathParameter('end', description: 'End date in YYYY-mm-dd format.', format: 'date')]
     public function show(string $serialNumber, string $start, string $end): ApiResource {
         $meter = $this->meterService->getBySerialNumber($serialNumber);
 

--- a/src/backend/app/Http/Controllers/MeterController.php
+++ b/src/backend/app/Http/Controllers/MeterController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\UpdateMeterRequest;
 use App\Http\Resources\ApiResource;
 use App\Models\Meter\Meter;
 use App\Services\MeterService;
+use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -18,13 +19,12 @@ class MeterController extends Controller {
     ) {}
 
     /**
-     * List
-     * Lists all used meters with meterType
-     * The response is paginated with 15 results on each page/request.
+     * List meters.
      *
-     * @urlParam     page int
-     * @urlParam     in_use int to list wether used or all meters
+     * Lists all used meters with their meter type.
+     * The response is paginated with 15 results on each page/request.
      */
+    #[QueryParameter('in_use', description: 'Whether to list only meters in use or all meters.', type: 'int')]
     public function index(Request $request): ApiResource {
         $inUse = $request->input('in_use');
         $limit = $request->input('limit', 15);
@@ -33,12 +33,7 @@ class MeterController extends Controller {
     }
 
     /**
-     * Create
-     * Stores a new meter.
-     *
-     * @bodyParam serial_number string required
-     * @bodyParam meter_type_id int required
-     * @bodyParam manufacturer_id int required
+     * Create a meter.
      *
      * @return mixed
      *
@@ -51,27 +46,25 @@ class MeterController extends Controller {
     }
 
     /**
-     * Detail
+     * Get meter details.
+     *
      * Detailed meter with following relations
      * - Tariff.tariff
      * - Meter Type
      * - Meter.connectionType
      * - Meter.connectionGroup
      * - Manufacturer.
-     *
-     * @urlParam serialNumber string
      */
     public function show(string $serialNumber): ApiResource {
         return ApiResource::make($this->meterService->getBySerialNumber($serialNumber));
     }
 
     /**
-     * Search
+     * Search meters.
+     *
      * The search term will be searched in following fields
      * - Tariff.name
      * - Serial number.
-     *
-     * @bodyParam term string required
      */
     public function search(): ApiResource {
         $term = request('term');
@@ -81,10 +74,9 @@ class MeterController extends Controller {
     }
 
     /**
-     * Delete
-     * Deletes the meter with its all releations.
+     * Delete a meter.
      *
-     * @urlParam meterId. The ID of the meter to be delete
+     * Deletes the meter with all its relations.
      */
     public function destroy(int $meterId): JsonResponse {
         $this->meterService->getById($meterId);

--- a/src/backend/app/Http/Controllers/MeterGeographicalInformationController.php
+++ b/src/backend/app/Http/Controllers/MeterGeographicalInformationController.php
@@ -19,11 +19,10 @@ class MeterGeographicalInformationController extends Controller {
     ) {}
 
     /**
-     * List with geo and access rate
-     * A list of meters with their positions and access rate payments
-     * The list is not paginated.
+     * List meters with geo and access rate.
      *
-     * @urlParam mini_grid_id int
+     * A list of meters with their positions and access rate payments.
+     * The list is not paginated.
      */
     public function index(?int $miniGridId = null): ApiResource {
         $cityIds = $miniGridId ? $this->cityService->getCityIdsByMiniGridId($miniGridId) : [];
@@ -38,27 +37,20 @@ class MeterGeographicalInformationController extends Controller {
     }
 
     /**
-     * @group    People
-     * Person with Meters & geo
+     * Get person meters with geo coordinates.
+     *
      * Person details with his/her owned meter(s) and the geo coordinates where each meter is placed
      * - Meters
      *   - Meter coordinates
      * A list of meters which belong to that given person
-     * The list is wether sorted or paginated
-     *
-     * @urlParam person required The ID of the person
+     * The list is neither sorted nor paginated.
      */
     public function show(int $personId): ApiResource {
         return ApiResource::make($this->personMeterService->getPersonMetersGeographicalInformation($personId));
     }
 
     /**
-     * Update
-     * Updates the geo coordinates of the meter.
-     *
-     * @urlParam  meter int
-     *
-     * @bodyParam points string. Comma seperated latitude and longitude. Example 1,2
+     * Update meter geo coordinates.
      */
     public function update(Request $request): ApiResource {
         $meters = $request->all();

--- a/src/backend/app/Http/Controllers/MeterRevenueController.php
+++ b/src/backend/app/Http/Controllers/MeterRevenueController.php
@@ -11,12 +11,9 @@ class MeterRevenueController extends Controller {
     ) {}
 
     /**
-     * Revenue
+     * Get meter revenue.
+     *
      * The total revenue that the meter made.
-     *
-     * @group     Meters
-     *
-     * @bodyParam serialNumber string required.
      */
     public function show(string $serialNumber): ApiResource {
         $revenue = $this->meterRevenueService->getBySerialNumber($serialNumber);

--- a/src/backend/app/Http/Controllers/MeterTypeController.php
+++ b/src/backend/app/Http/Controllers/MeterTypeController.php
@@ -9,17 +9,13 @@ use App\Services\MeterTypeService;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Http\Request;
 
-/**
- * @group   MeterTypes
- * Class MeterTypeController
- */
 class MeterTypeController extends Controller {
     use SoftDeletes;
 
     public function __construct(private MeterTypeService $meterTypeService) {}
 
     /**
-     * List.
+     * List meter types.
      */
     public function index(Request $request): ApiResource {
         $limit = $request->input('limit');
@@ -28,12 +24,7 @@ class MeterTypeController extends Controller {
     }
 
     /**
-     * Store
-     * Creates a new meter type.
-     *
-     * @bodyParam online int required
-     * @bodyParam phase int required
-     * @bodyParam max_current int required
+     * Create a meter type.
      *
      * @return ApiResource
      */
@@ -44,23 +35,14 @@ class MeterTypeController extends Controller {
     }
 
     /**
-     * Detail.
-     *
-     * @bodyParam id int required
+     * Get meter type details.
      */
     public function show(int $meterTypeId): ApiResource {
         return ApiResource::make($this->meterTypeService->getById($meterTypeId));
     }
 
     /**
-     * Update
-     * Updates the given meter type.
-     *
-     * @urlParam  id required
-     *
-     * @bodyParam online int required
-     * @bodyParam phase int required
-     * @bodyParam max_current int required
+     * Update a meter type.
      */
     public function update(MeterTypeUpdateRequest $request, int $meterTypeId): ApiResource {
         $meterType = $this->meterTypeService->getById($meterTypeId);

--- a/src/backend/app/Http/Controllers/MeterTypeMeterController.php
+++ b/src/backend/app/Http/Controllers/MeterTypeMeterController.php
@@ -10,10 +10,9 @@ class MeterTypeMeterController extends Controller {
     public function __construct(private MeterTypeMeterService $meterTypeMeterService) {}
 
     /**
-     * List with Meters
-     * Displays the meter types with the associated meters.
+     * List meters of a meter type.
      *
-     * @urlParam id required
+     * Displays the meter type with its associated meters.
      *
      * @return ApiResource
      */

--- a/src/backend/app/Http/Controllers/MiniGridController.php
+++ b/src/backend/app/Http/Controllers/MiniGridController.php
@@ -15,7 +15,7 @@ class MiniGridController extends Controller {
     ) {}
 
     /**
-     * List.
+     * List mini-grids.
      */
     public function index(Request $request): ApiResource {
         $limit = $request->input('per_page');
@@ -24,9 +24,7 @@ class MiniGridController extends Controller {
     }
 
     /**
-     * Detail.
-     *
-     * @bodyParam id int required
+     * Get mini-grid details.
      */
     public function show(int $miniGridId, Request $request): ApiResource {
         $relation = $request->input('relation');

--- a/src/backend/app/Http/Controllers/PaymentHistoryController.php
+++ b/src/backend/app/Http/Controllers/PaymentHistoryController.php
@@ -9,11 +9,8 @@ use App\Models\PaymentHistory;
 use App\Models\Person\Person;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Dedoc\Scramble\Attributes\BodyParameter;
 
-/**
- * @group   Payment-History
- * Class PaymentHistoryController
- */
 class PaymentHistoryController {
     /**
      * PaymentHistoryController constructor.
@@ -21,12 +18,7 @@ class PaymentHistoryController {
     public function __construct(private PaymentHistory $history) {}
 
     /**
-     * Detail.
-     *
-     * @urlParam payerId integer required
-     * @urlParam period string required
-     * @urlParam limit integer
-     * @urlParam order string
+     * Get person payment flow grouped by period.
      *
      * @return array<string, array<string, mixed>>
      */
@@ -50,9 +42,7 @@ class PaymentHistoryController {
     }
 
     /**
-     * Payment Periods.
-     *
-     * @urlParam personId integer required
+     * Get person payment period overview.
      *
      * @throws \Exception
      */
@@ -73,9 +63,7 @@ class PaymentHistoryController {
     }
 
     /**
-     * Person payment flow per year.
-     *
-     * @urlParam personId integer required
+     * Get person payment flow per year.
      *
      * @return array<int, float>
      */
@@ -91,10 +79,9 @@ class PaymentHistoryController {
     }
 
     /**
-     * Person Debts.
+     * Get person debts.
      *
-     * @urlParam personId integer required
-     * checks if the person has any debts to the system
+     * Checks if the person has any debts to the system.
      */
     public function debts(int $personId): ApiResource {
         $accessRateDebt = 0;
@@ -117,13 +104,12 @@ class PaymentHistoryController {
     }
 
     /**
-     * Payments list with date range.
-     *
-     * @bodyParam begin string
-     * @bodyParam end string
+     * List payments within a date range.
      *
      * @throws \Exception
      */
+    #[BodyParameter('begin', description: 'Start date of the range.', type: 'string', format: 'date')]
+    #[BodyParameter('end', description: 'End date of the range.', type: 'string', format: 'date')]
     public function getPaymentRange(): ApiResource {
         $begin = request('begin'); // Y-m-d
         $end = request('end'); // Y-m- d

--- a/src/backend/app/Http/Controllers/PersonAddressesController.php
+++ b/src/backend/app/Http/Controllers/PersonAddressesController.php
@@ -17,12 +17,9 @@ class PersonAddressesController extends Controller {
     ) {}
 
     /**
-     * Addresses
+     * List person addresses.
+     *
      * A list of registered addresses for that person.
-     *
-     * @bodyParam    person int required the ID of the person. Example: 2
-     *
-     * @apiResourceModel \App\Models\Person\Person
      */
     public function show(int $personId): ApiResource {
         $person = $this->personService->getById($personId);

--- a/src/backend/app/Http/Controllers/PersonController.php
+++ b/src/backend/app/Http/Controllers/PersonController.php
@@ -9,15 +9,11 @@ use App\Services\AddressesService;
 use App\Services\CountryService;
 use App\Services\PersonAddressService;
 use App\Services\PersonService;
+use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-/**
- * Class PersonController.
- *
- * @group People
- */
 class PersonController extends Controller {
     public function __construct(
         private AddressesService $addressService,
@@ -27,22 +23,22 @@ class PersonController extends Controller {
     ) {}
 
     /**
-     * List customer/other
-     * [ To get a list of registered customers or non-customer like contact person of Meter Manufacturer. ].
+     * List people.
      *
-     * @urlParam is_customer int optinal. To get a list of customers or non customer. Default : 1
-     * @urlParam agent_id int optional. To get a list of customers of a specific agent.
-     * @urlParam limit int optional. The number of items per page.
-     * @urlParam active_customer int optional. To get a list of active customers. Default: 0
-     * @urlParam city_id int optional. Filter by primary address city/village id.
-     * @urlParam total_paid_min float optional. Minimum total paid amount for the customer.
-     * @urlParam total_paid_max float optional. Maximum total paid amount for the customer.
-     * @urlParam latest_payment_from string optional. ISO date string for minimum latest payment date.
-     * @urlParam latest_payment_to string optional. ISO date string for maximum latest payment date.
-     * @urlParam registration_from string optional. ISO date string for minimum registration date.
-     * @urlParam registration_to string optional. ISO date string for maximum registration date.
-     * @urlParam device_type string optional. Filter by device/appliance type.
+     * To get a list of registered customers or non-customers, like the contact person of a meter manufacturer.
      */
+    #[QueryParameter('is_customer', description: 'To get a list of customers or non customer.', type: 'int', default: 1)]
+    #[QueryParameter('agent_id', description: 'To get a list of customers of a specific agent.', type: 'int')]
+    #[QueryParameter('per_page', description: 'The number of items per page.', type: 'int', default: 15)]
+    #[QueryParameter('active_customer', description: 'To get a list of active customers.', type: 'int', default: 0)]
+    #[QueryParameter('city_id', description: 'Filter by primary address city/village id.', type: 'int')]
+    #[QueryParameter('total_paid_min', description: 'Minimum total paid amount for the customer.', type: 'float')]
+    #[QueryParameter('total_paid_max', description: 'Maximum total paid amount for the customer.', type: 'float')]
+    #[QueryParameter('latest_payment_from', description: 'ISO date string for minimum latest payment date.', type: 'string')]
+    #[QueryParameter('latest_payment_to', description: 'ISO date string for maximum latest payment date.', type: 'string')]
+    #[QueryParameter('registration_from', description: 'ISO date string for minimum registration date.', type: 'string')]
+    #[QueryParameter('registration_to', description: 'ISO date string for maximum registration date.', type: 'string')]
+    #[QueryParameter('device_type', description: 'Filter by device/appliance type.', type: 'string')]
     public function index(Request $request): ApiResource {
         $customerType = $request->input('is_customer', 1);
         $perPage = $request->input('per_page', 15);
@@ -76,21 +72,20 @@ class PersonController extends Controller {
     }
 
     /**
-     * Detail
+     * Get person details.
+     *
      * Displays the person with following relations
      * - Addresses
      * - Citizenship
      * - Role
      * - Meter list.
-     *
-     * @apiResourceModel App\Models\Person\Person
      */
     public function show(int $personId): ApiResource {
         return ApiResource::make($this->personService->getDetails($personId, true));
     }
 
     /**
-     * Create.
+     * Create a person.
      */
     public function store(PersonRequest $request): JsonResponse {
         try {
@@ -126,19 +121,9 @@ class PersonController extends Controller {
     }
 
     /**
-     * Update
+     * Update a person.
+     *
      * Updates the given parameter of that person.
-     *
-     * @urlParam  id required The ID of the person to update
-     *
-     * @bodyParam title string. The title of the person. Example: Dr.
-     * @bodyParam name string. The title of the person. Example: Dr.
-     * @bodyParam surname string. The title of the person. Example: Dr.
-     * @bodyParam birth_date string. The title of the person. Example: Dr.
-     * @bodyParam gender string. The title of the person. Example: Dr.
-     * @bodyParam education string. The title of the person. Example: Dr.
-     *
-     * @apiResourceModel App\Models\Person\Person
      */
     public function update(
         int $personId,
@@ -151,11 +136,10 @@ class PersonController extends Controller {
     }
 
     /**
-     * Transactions
+     * List person transactions.
+     *
      * The list of all transactions(paginated) which belong to that person.
      * Each page contains 7 entries of the last transaction.
-     *
-     * @bodyParam    person_id int required the ID of the person. Example: 2
      */
     public function transactions(
         int $personId,
@@ -166,17 +150,16 @@ class PersonController extends Controller {
     }
 
     /**
-     * Search
+     * Search people.
+     *
      * Searches in person list according to the search term.
-     *  Term could be one of the following attributes;
+     * Term could be one of the following attributes;
      * - phone number
      * - meter serial number
      * - name
      * - surname.
-     *
-     * @urlParam term  The ID of the post. Example: John Doe
-     * @urlParam paginage int The page number. Example:1
      */
+    #[QueryParameter('term', description: 'The search term.', type: 'string', example: 'John Doe')]
     public function search(
         Request $request,
     ): ApiResource {
@@ -188,15 +171,12 @@ class PersonController extends Controller {
     }
 
     /**
-     * Delete
-     * Deletes that person with all his/her relations from the database. The person model uses soft deletes.
-     * That means the orinal record wont be deleted but all mentioned relations will be removed permanently.
+     * Delete a person.
      *
-     * @urlParam person required The ID of the person. Example:1
+     * Deletes that person with all his/her relations from the database. The person model uses soft deletes.
+     * That means the original record wont be deleted but all mentioned relations will be removed permanently.
      *
      * @throws \Exception
-     *
-     * @apiResourceModel App\Models\Person\Person
      */
     public function destroy(
         int $personId,

--- a/src/backend/app/Http/Controllers/PersonMeterController.php
+++ b/src/backend/app/Http/Controllers/PersonMeterController.php
@@ -11,11 +11,9 @@ class PersonMeterController {
     ) {}
 
     /**
-     * @group    People
-     * Person with Meters & Tariff
-     * Person details with his/her owned meter(s) and its assigned tariff
+     * Get person meters with tariffs.
      *
-     * @urlParam person required The ID of the person
+     * Person details with his/her owned meter(s) and its assigned tariff.
      */
     public function show(int $personId): ApiResource {
         return ApiResource::make($this->personMeterService->getPersonMeters($personId));

--- a/src/backend/app/Http/Controllers/Reports.php
+++ b/src/backend/app/Http/Controllers/Reports.php
@@ -27,11 +27,6 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Exception;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
-/**
- * Class Reports.
- *
- * @group Export
- */
 class Reports {
     /** @var array<string, array{energy: int, access_rate: int, unit: float}> */
     private array $totalSold = [];

--- a/src/backend/app/Http/Controllers/TariffController.php
+++ b/src/backend/app/Http/Controllers/TariffController.php
@@ -15,8 +15,9 @@ class TariffController extends Controller {
     ) {}
 
     /**
-     * List
-     * a list of all tariffs.
+     * List tariffs.
+     *
+     * A list of all tariffs.
      * The list is paginated and each page contains 15 results.
      */
     public function index(Request $request): ApiResource {
@@ -26,21 +27,14 @@ class TariffController extends Controller {
     }
 
     /**
-     * Detail.
-     *
-     * @urlParam     id int required
+     * Get tariff details.
      */
     public function show(Request $request, int $tariffId): ApiResource {
         return ApiResource::make($this->tariffService->getById($tariffId));
     }
 
     /**
-     * Create.
-     *
-     * @bodyParam name string required
-     * @bodyParam factor int. The factor between two different sub tariffs. Like day/night sub-tariffs.
-     * @bodyParam currency string
-     * @bodyParam price int required.
+     * Create a tariff.
      */
     public function store(TariffCreateRequest $request): JsonResponse {
         $tariffData = $request->only(['name', 'factor', 'currency', 'price', 'minimum_purchase_amount']);

--- a/src/backend/app/Http/Requests/CityRequest.php
+++ b/src/backend/app/Http/Requests/CityRequest.php
@@ -5,12 +5,6 @@ namespace App\Http\Requests;
 use App\Rules\GeoJsonPoint;
 use Illuminate\Foundation\Http\FormRequest;
 
-/**
- * @bodyParam name string required The name of the village.
- * @bodyParam mini_grid_id int required The id of the mini-grid the village belongs to.
- * @bodyParam country_id int required The id of the country the village belongs to.
- * @bodyParam geo_json object required The GPS location of the village as a GeoJSON Point Feature.
- */
 class CityRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
@@ -26,9 +20,13 @@ class CityRequest extends FormRequest {
      */
     public function rules(): array {
         return [
+            // The name of the village.
             'name' => ['required'],
+            // The id of the mini-grid the village belongs to.
             'mini_grid_id' => ['required'],
+            // The id of the country the village belongs to.
             'country_id' => ['required', 'integer', 'exists:tenant.countries,id'],
+            // The GPS location of the village as a GeoJSON Point Feature.
             'geo_json' => ['required', 'array', new GeoJsonPoint()],
         ];
     }

--- a/src/backend/app/Http/Requests/ClusterRequest.php
+++ b/src/backend/app/Http/Requests/ClusterRequest.php
@@ -4,14 +4,6 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-/**
- * @urlParam  id required The ID of the post.
- * @urlParam  lang The language.
- *
- * @bodyParam name string required The name  of the cluster.
- * @bodyParam geo_json string required. GeoJSON polygon coordinates.
- * @bodyParam manager_id int required. The id of the user who is responsible for the cluster.
- */
 class ClusterRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
@@ -27,8 +19,11 @@ class ClusterRequest extends FormRequest {
      */
     public function rules(): array {
         return [
+            // The name of the cluster.
             'name' => ['required'],
+            // GeoJSON polygon coordinates.
             'geo_json' => ['required'],
+            // The id of the user who is responsible for the cluster.
             'manager_id' => ['required'],
         ];
     }

--- a/src/backend/app/Http/Requests/CreateAddressRequest.php
+++ b/src/backend/app/Http/Requests/CreateAddressRequest.php
@@ -15,8 +15,6 @@ class CreateAddressRequest extends FormRequest {
     /**
      * Get the validation rules that apply to the request.
      *
-     * @bodyParam city_id int required
-     *
      * @return array<string, mixed>
      */
     public function rules(): array {

--- a/src/backend/app/Http/Requests/PersonRequest.php
+++ b/src/backend/app/Http/Requests/PersonRequest.php
@@ -4,19 +4,6 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-/**
- * @bodyParam title string optional. The title of the person. Example: Dr.
- * @bodyParam name string required. Example: John
- * @bodyParam surname string required. Example: Doe
- * @bodyParam birth_date string optional. Example: 1970-01-01
- * @bodyParam gender string optional Example: male
- * @bodyParam education string optional. Example: University
- * @bodyParam city_id int optional. Example: 1
- * @bodyParam street string optional. Example: Some Street 1/13
- * @bodyParam email string optional. Example: john.doe@mail.com
- * @bodyParam phone string optional. Example: +1111
- * @bodyParam country_code string optional. Example: NG, US, etc.
- */
 class PersonRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
@@ -32,16 +19,48 @@ class PersonRequest extends FormRequest {
      */
     public function rules(): array {
         return [
+            /*
+             * The title of the person.
+             *
+             * @example Dr.
+             */
             'title' => ['sometimes', 'nullable', 'string'],
+            /*
+             * @example John
+             */
             'name' => ['required', 'min:2'],
+            /*
+             * @example Doe
+             */
             'surname' => ['required', 'min:2'],
+            /*
+             * @example 1970-01-01
+             */
             'birth_date' => ['sometimes', 'nullable', 'date'],
+            /*
+             * @example male
+             */
             'gender' => ['sometimes', 'nullable', 'string'],
+            /*
+             * @example University
+             */
             'education' => ['sometimes', 'nullable', 'string'],
             'city_id' => ['sometimes', 'integer', 'exists:tenant.cities,id'],
+            /*
+             * @example Some Street 1/13
+             */
             'street' => ['sometimes', 'nullable', 'string', 'min:5'],
+            /*
+             * @example john.doe@mail.com
+             */
             'email' => ['sometimes', 'nullable', 'email'],
+            /*
+             * @example +1111
+             */
             'phone' => ['sometimes', 'min:11'],
+            /*
+             * @example NG
+             */
             'country_code' => ['sometimes', 'nullable', 'string'],
         ];
     }

--- a/src/backend/app/Http/Requests/StoreMiniGridRequest.php
+++ b/src/backend/app/Http/Requests/StoreMiniGridRequest.php
@@ -5,11 +5,6 @@ namespace App\Http\Requests;
 use App\Rules\GeoJsonPoint;
 use Illuminate\Foundation\Http\FormRequest;
 
-/**
- * @bodyParam name string required The name of the mini-grid.
- * @bodyParam cluster_id int required The id of the cluster that owns the mini-grid.
- * @bodyParam geo_json object required The GPS location of the mini-grid as a GeoJSON Point Feature.
- */
 class StoreMiniGridRequest extends FormRequest {
     /**
      * Determine if the user is authorized to make this request.
@@ -25,8 +20,11 @@ class StoreMiniGridRequest extends FormRequest {
      */
     public function rules(): array {
         return [
+            // The name of the mini-grid.
             'name' => ['required', 'min:3'],
+            // The id of the cluster that owns the mini-grid.
             'cluster_id' => ['required'],
+            // The GPS location of the mini-grid as a GeoJSON Point Feature.
             'geo_json' => ['required', 'array', new GeoJsonPoint()],
         ];
     }

--- a/src/backend/app/Http/Requests/TariffCreateRequest.php
+++ b/src/backend/app/Http/Requests/TariffCreateRequest.php
@@ -25,6 +25,7 @@ class TariffCreateRequest extends FormRequest {
             'name' => ['required'],
             'price' => ['required', 'numeric'], // 100 times of original price to support 2 decimal numbers.
             'currency' => ['required', 'string', 'max:20'],
+            // The factor between two different sub tariffs. Like day/night sub-tariffs.
             'factor' => ['sometimes', 'integer'],
             'access_rate_period' => ['integer', 'min:1'],
             'access_rate_amount' => ['integer'],

--- a/src/backend/app/Http/Requests/UpdateCityRequest.php
+++ b/src/backend/app/Http/Requests/UpdateCityRequest.php
@@ -5,14 +5,6 @@ namespace App\Http\Requests;
 use App\Rules\GeoJsonPoint;
 use Illuminate\Foundation\Http\FormRequest;
 
-/**
- * @urlParam cityId required The ID of the village (city).
- *
- * @bodyParam name string The name of the village.
- * @bodyParam mini_grid_id int The id of the mini-grid the village belongs to.
- * @bodyParam country_id int The id of the country the village belongs to.
- * @bodyParam geo_json object The GPS location of the village as a GeoJSON Point Feature.
- */
 class UpdateCityRequest extends FormRequest {
     public function authorize(): bool {
         return true;
@@ -23,9 +15,13 @@ class UpdateCityRequest extends FormRequest {
      */
     public function rules(): array {
         return [
+            // The name of the village.
             'name' => ['sometimes', 'string', 'min:1'],
+            // The id of the mini-grid the village belongs to.
             'mini_grid_id' => ['sometimes', 'integer', 'exists:tenant.mini_grids,id'],
+            // The id of the country the village belongs to.
             'country_id' => ['sometimes', 'integer', 'exists:tenant.countries,id'],
+            // The GPS location of the village as a GeoJSON Point Feature.
             'geo_json' => ['sometimes', 'array', new GeoJsonPoint()],
         ];
     }

--- a/src/backend/app/Http/Requests/UpdateClusterRequest.php
+++ b/src/backend/app/Http/Requests/UpdateClusterRequest.php
@@ -2,21 +2,17 @@
 
 namespace App\Http\Requests;
 
-/**
- * @urlParam clusterId required The ID of the cluster.
- *
- * @bodyParam name string The name of the cluster.
- * @bodyParam geo_json object GeoJSON polygon coordinates.
- * @bodyParam manager_id int The id of the user who is responsible for the cluster.
- */
 class UpdateClusterRequest extends ClusterRequest {
     /**
      * @return array<string, mixed>
      */
     public function rules(): array {
         return [
+            // The name of the cluster.
             'name' => ['sometimes', 'string', 'min:1'],
+            // GeoJSON polygon coordinates.
             'geo_json' => ['sometimes'],
+            // The id of the user who is responsible for the cluster.
             'manager_id' => ['sometimes', 'integer'],
         ];
     }

--- a/src/backend/app/Http/Requests/UpdateMiniGridRequest.php
+++ b/src/backend/app/Http/Requests/UpdateMiniGridRequest.php
@@ -5,13 +5,6 @@ namespace App\Http\Requests;
 use App\Rules\GeoJsonPoint;
 use Illuminate\Foundation\Http\FormRequest;
 
-/**
- * @urlParam miniGridId required The ID of the mini-grid.
- *
- * @bodyParam name string The name of the mini-grid.
- * @bodyParam cluster_id int The id of the cluster that owns the mini-grid.
- * @bodyParam geo_json object The GPS location of the mini-grid as a GeoJSON Point Feature.
- */
 class UpdateMiniGridRequest extends FormRequest {
     public function authorize(): bool {
         return true;
@@ -22,8 +15,11 @@ class UpdateMiniGridRequest extends FormRequest {
      */
     public function rules(): array {
         return [
+            // The name of the mini-grid.
             'name' => ['sometimes', 'string', 'min:1'],
+            // The id of the cluster that owns the mini-grid.
             'cluster_id' => ['sometimes', 'integer', 'exists:tenant.clusters,id'],
+            // The GPS location of the mini-grid as a GeoJSON Point Feature.
             'geo_json' => ['sometimes', 'array', new GeoJsonPoint()],
         ];
     }

--- a/src/backend/app/Plugins/SafaricomKePaymentProvider/Http/Controllers/SafaricomTransactionController.php
+++ b/src/backend/app/Plugins/SafaricomKePaymentProvider/Http/Controllers/SafaricomTransactionController.php
@@ -98,6 +98,8 @@ class SafaricomTransactionController extends Controller {
     }
 
     /**
+     * Get the status of a transaction.
+     *
      * Polled by the STK Push page while the customer is entering their PIN.
      * For pending transactions this hits Daraja's STK Push Query so we don't
      * have to wait for the (frequently delayed) async callback. Once the

--- a/src/backend/app/Plugins/VodacomMzPaymentProvider/Http/Controllers/VodacomMzTransactionController.php
+++ b/src/backend/app/Plugins/VodacomMzPaymentProvider/Http/Controllers/VodacomMzTransactionController.php
@@ -10,12 +10,7 @@ use App\Plugins\VodacomMzPaymentProvider\Http\Resources\VodacomTransactionResour
 use App\Plugins\VodacomMzPaymentProvider\Services\VodacomMzTransactionService;
 use Dedoc\Scramble\Attributes\Group;
 
-/**
- * @group Vodacom Transaction
- *
- * API endpoints for integrating with Vodacom's M-Pesa payment services
- */
-#[Group('Plugins / Vodacom Mz')]
+#[Group('Plugins / Vodacom Mz', "API endpoints for integrating with Vodacom's M-Pesa payment services")]
 class VodacomMzTransactionController extends Controller {
     public function __construct(
         private VodacomMzTransactionService $vodacomService,
@@ -44,24 +39,6 @@ class VodacomMzTransactionController extends Controller {
      *
      * Processes a previously validated transaction. This endpoint should be called after successful
      * validation to initiate the payment process with Vodacom M-Pesa.
-     *
-     * @bodyParam referenceId string required The reference ID used during validation pattern: ^[A-Za-z0-9\-]{5,20}$ Example: ORD-12345-ABC
-     * @bodyParam transactionId string required The transaction ID returned from the validation step pattern: ^VOD-TXN-[0-9]{6}$ Example: VOD-TXN-123456
-     *
-     * @response scenario="Success" {
-     *   "data": {
-     *     "transactionId": "VOD-TXN-123456",
-     *     "status": "processing",
-     *     "providerReference": "MPESA-TX-987654321",
-     *     "success": true
-     *   }
-     * }
-     * @response 400 scenario="Processing Error" {
-     *   "data": {
-     *     "message": "Transaction processing failed: Insufficient funds",
-     *     "success": false
-     *   }
-     * }
      */
     public function processTransaction(VodacomTransactionProcessRequest $request): VodacomTransactionResource {
         $validatedData = $request->validated();
@@ -80,25 +57,6 @@ class VodacomMzTransactionController extends Controller {
      *
      * Checks the current status of a transaction that has been submitted for processing.
      * Use this to verify if a payment has been completed, is still pending, or has failed.
-     *
-     * @bodyParam referenceId string required The reference ID of the transaction to check pattern: ^[A-Za-z0-9\-]{5,20}$ Example: ORD-12345-ABC
-     *
-     * @response scenario="Success" {
-     *   "data": {
-     *     "referenceId": "ORD-12345-ABC",
-     *     "transactionId": "VOD-TXN-123456",
-     *     "status": "completed",
-     *     "mpesaReceipt": "QCL4521XYZ",
-     *     "completedAt": "2023-06-15T12:45:32Z",
-     *     "success": true
-     *   }
-     * }
-     * @response 400 scenario="Enquiry Error" {
-     *   "data": {
-     *     "message": "Transaction not found or reference ID is invalid",
-     *     "success": false
-     *   }
-     * }
      */
     public function queryTransactionStatus(VodacomTransactionEnquiryStatusRequest $request): VodacomTransactionResource {
         $validatedData = $request->validated();


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Noticed some leftover and redundant `@bodyParam` from Scribe. Since we are now using Scramble these tags are defunct. Removing them here. Replacing with Scramble annotations where needed.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
