### PR TITLE
improve export endpoints api docs by grouping and adding more context to the response/requests

### DIFF
--- a/src/backend/app/Http/Controllers/ApplianceExportController.php
+++ b/src/backend/app/Http/Controllers/ApplianceExportController.php
@@ -3,13 +3,19 @@
 namespace App\Http\Controllers;
 
 use App\Services\ApplianceService;
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\ApplianceExportService;
 use App\Services\MainSettingsService;
+use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class ApplianceExportController extends Controller {
     public function __construct(
         private ApplianceService $applianceService,
@@ -17,21 +23,30 @@ class ApplianceExportController extends Controller {
         private MainSettingsService $mainSettingsService,
     ) {}
 
+    /**
+     * Export appliances.
+     *
+     * Downloads appliances as an Excel or CSV file, or returns them as JSON.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    #[QueryParameter('format', description: 'Export format.', type: "'excel'|'csv'|'json'", default: 'excel')]
     public function download(Request $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'excel');
 
         if ($format === 'csv') {
-            return $this->downloadCsv($request);
+            return $this->downloadCsv();
         }
 
         if ($format === 'json') {
-            return $this->downloadJson($request);
+            return $this->downloadJson();
         }
 
-        return $this->downloadExcel($request);
+        return $this->downloadExcel();
     }
 
-    public function downloadExcel(Request $request): StreamedResponse {
+    public function downloadExcel(): StreamedResponse {
         $mainSettings = $this->mainSettingsService->getAll()->first();
         $this->applianceExportService->setCurrency($mainSettings->currency);
 
@@ -42,10 +57,10 @@ class ApplianceExportController extends Controller {
         $this->applianceExportService->writeApplianceData();
         $pathToSpreadSheet = $this->applianceExportService->saveSpreadSheet();
 
-        return Storage::download($pathToSpreadSheet, 'appliance_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'appliance_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadCsv(Request $request): StreamedResponse {
+    public function downloadCsv(): StreamedResponse {
         $mainSettings = $this->mainSettingsService->getAll()->first();
         $this->applianceExportService->setCurrency($mainSettings->currency);
 
@@ -56,10 +71,10 @@ class ApplianceExportController extends Controller {
         $headers = ['Appliance Name', 'Appliance Type', 'Price', 'Total Sold', 'Total Rates', 'Created At', 'Updated At'];
         $csvPath = $this->applianceExportService->saveCsv($headers);
 
-        return Storage::download($csvPath, 'appliance_export_'.now()->format('Ymd_His').'.csv');
+        return Storage::download($csvPath, 'appliance_export_'.now()->format('Ymd_His').'.csv', ['Content-Type' => AbstractExportService::CSV_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(): JsonResponse {
         $mainSettings = $this->mainSettingsService->getAll()->first();
         $this->applianceExportService->setCurrency($mainSettings->currency);
 

--- a/src/backend/app/Http/Controllers/ClusterExportController.php
+++ b/src/backend/app/Http/Controllers/ClusterExportController.php
@@ -3,33 +3,48 @@
 namespace App\Http\Controllers;
 
 use App\Services\ClusterService;
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\ClusterExportService;
+use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class ClusterExportController extends Controller {
     public function __construct(
         private ClusterService $clusterService,
         private ClusterExportService $clusterExportService,
     ) {}
 
+    /**
+     * Export clusters.
+     *
+     * Downloads clusters as an Excel or CSV file, or returns them as JSON.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    #[QueryParameter('format', description: 'Export format.', type: "'excel'|'csv'|'json'", default: 'excel')]
     public function download(Request $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'excel');
 
         if ($format === 'csv') {
-            return $this->downloadCsv($request);
+            return $this->downloadCsv();
         }
 
         if ($format === 'json') {
-            return $this->downloadJson($request);
+            return $this->downloadJson();
         }
 
-        return $this->downloadExcel($request);
+        return $this->downloadExcel();
     }
 
-    public function downloadExcel(Request $request): StreamedResponse {
+    public function downloadExcel(): StreamedResponse {
         $clusters = $this->clusterService->getAllForExport();
         $this->clusterExportService->createSpreadSheetFromTemplate($this->clusterExportService->getTemplatePath());
         $this->clusterExportService->setClusterData($clusters);
@@ -37,10 +52,10 @@ class ClusterExportController extends Controller {
         $this->clusterExportService->writeClusterData();
         $pathToSpreadSheet = $this->clusterExportService->saveSpreadSheet();
 
-        return Storage::download($pathToSpreadSheet, 'cluster_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'cluster_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadCsv(Request $request): StreamedResponse {
+    public function downloadCsv(): StreamedResponse {
         $clusters = $this->clusterService->getAllForExport();
 
         $this->clusterExportService->setClusterData($clusters);
@@ -48,10 +63,10 @@ class ClusterExportController extends Controller {
         $headers = ['Cluster Name', 'Manager', 'Mini Grids Count', 'Cities Count', 'Created At', 'Updated At'];
         $csvPath = $this->clusterExportService->saveCsv($headers);
 
-        return Storage::download($csvPath, 'cluster_export_'.now()->format('Ymd_His').'.csv');
+        return Storage::download($csvPath, 'cluster_export_'.now()->format('Ymd_His').'.csv', ['Content-Type' => AbstractExportService::CSV_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(): JsonResponse {
         $clusters = $this->clusterService->getAllForExport();
 
         $this->clusterExportService->setClusterData($clusters);

--- a/src/backend/app/Http/Controllers/DeviceExportController.php
+++ b/src/backend/app/Http/Controllers/DeviceExportController.php
@@ -2,20 +2,33 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\DeviceExportRequest;
 use App\Services\DeviceService;
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\DeviceExportService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class DeviceExportController extends Controller {
     public function __construct(
         private DeviceService $deviceService,
         private DeviceExportService $deviceExportService,
     ) {}
 
-    public function download(Request $request): StreamedResponse|JsonResponse {
+    /**
+     * Export devices.
+     *
+     * Downloads devices as an Excel or CSV file, or returns them as JSON.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    public function download(DeviceExportRequest $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'excel');
 
         if ($format === 'csv') {
@@ -29,7 +42,7 @@ class DeviceExportController extends Controller {
         return $this->downloadExcel($request);
     }
 
-    public function downloadExcel(Request $request): StreamedResponse {
+    public function downloadExcel(DeviceExportRequest $request): StreamedResponse {
         $miniGridName = $request->input('miniGrid');
         $villageName = $request->input('village');
         $deviceType = $request->input('deviceType');
@@ -42,10 +55,10 @@ class DeviceExportController extends Controller {
         $this->deviceExportService->writeDeviceData();
         $pathToSpreadSheet = $this->deviceExportService->saveSpreadSheet();
 
-        return Storage::download($pathToSpreadSheet, 'device_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'device_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadCsv(Request $request): StreamedResponse {
+    public function downloadCsv(DeviceExportRequest $request): StreamedResponse {
         $miniGridName = $request->input('miniGrid');
         $villageName = $request->input('village');
         $deviceType = $request->input('deviceType');
@@ -58,10 +71,10 @@ class DeviceExportController extends Controller {
         $headers = ['Device Serial', 'Device Type', 'Customer', 'Address', 'Manufacturer', 'Created At', 'Updated At'];
         $csvPath = $this->deviceExportService->saveCsv($headers);
 
-        return Storage::download($csvPath, 'device_export_'.now()->format('Ymd_His').'.csv');
+        return Storage::download($csvPath, 'device_export_'.now()->format('Ymd_His').'.csv', ['Content-Type' => AbstractExportService::CSV_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(DeviceExportRequest $request): JsonResponse {
         $miniGridName = $request->input('miniGrid');
         $villageName = $request->input('village');
         $deviceType = $request->input('deviceType');

--- a/src/backend/app/Http/Controllers/OutstandingDebtsExportController.php
+++ b/src/backend/app/Http/Controllers/OutstandingDebtsExportController.php
@@ -5,36 +5,51 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Services\ApplianceRateService;
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\OutstandingDebtsExportService;
 use Carbon\CarbonImmutable;
+use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class OutstandingDebtsExportController {
     public function __construct(
         private OutstandingDebtsExportService $outstandingDebtsExportService,
         private ApplianceRateService $applianceRateService,
     ) {}
 
+    /**
+     * Export outstanding debts.
+     *
+     * Downloads outstanding appliance debts as an Excel file, or returns them as JSON.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    #[QueryParameter('format', description: 'Export format.', type: "'excel'|'json'", default: 'excel')]
     public function download(Request $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'excel');
 
         if ($format === 'json') {
-            return $this->downloadJson($request);
+            return $this->downloadJson();
         }
 
-        return $this->downloadExcel($request);
+        return $this->downloadExcel();
     }
 
-    public function downloadExcel(Request $request): StreamedResponse {
+    public function downloadExcel(): StreamedResponse {
         $pathToSpreadSheet = $this->outstandingDebtsExportService->createReport(CarbonImmutable::now());
 
-        return Storage::download($pathToSpreadSheet, 'outstanding_debts_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'outstanding_debts_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(): JsonResponse {
         $toDate = CarbonImmutable::now();
         $currency = $this->applianceRateService->getCurrencyFromMainSettings();
         $data = $this->applianceRateService->queryOutstandingDebtsByApplianceRates($toDate)->get();

--- a/src/backend/app/Http/Controllers/PersonExportController.php
+++ b/src/backend/app/Http/Controllers/PersonExportController.php
@@ -2,20 +2,33 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\PersonExportRequest;
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\PersonExportService;
 use App\Services\PersonService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class PersonExportController extends Controller {
     public function __construct(
         private PersonService $personService,
         private PersonExportService $peopleExportService,
     ) {}
 
-    public function download(Request $request): StreamedResponse|JsonResponse {
+    /**
+     * Export customers.
+     *
+     * Downloads customer records as an Excel or CSV file, or returns them as JSON.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    public function download(PersonExportRequest $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'excel');
 
         if ($format === 'csv') {
@@ -29,7 +42,7 @@ class PersonExportController extends Controller {
         return $this->downloadExcel($request);
     }
 
-    public function downloadExcel(Request $request): StreamedResponse {
+    public function downloadExcel(PersonExportRequest $request): StreamedResponse {
         $miniGridName = $request->input('miniGrid');
         $villageName = $request->input('village');
         $deviceType = $request->input('deviceType');
@@ -43,10 +56,10 @@ class PersonExportController extends Controller {
         $this->peopleExportService->writePeopleData();
         $pathToSpreadSheet = $this->peopleExportService->saveSpreadSheet();
 
-        return Storage::download($pathToSpreadSheet, 'customer_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'customer_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadCsv(Request $request): StreamedResponse {
+    public function downloadCsv(PersonExportRequest $request): StreamedResponse {
         $miniGridName = $request->input('miniGrid');
         $villageName = $request->input('village');
         $deviceType = $request->input('deviceType');
@@ -60,10 +73,10 @@ class PersonExportController extends Controller {
         $this->peopleExportService->setExportingData();
         $csvPath = $this->peopleExportService->saveCsv(PersonExportService::HEADERS);
 
-        return Storage::download($csvPath, 'customer_export_'.now()->format('Ymd_His').'.csv');
+        return Storage::download($csvPath, 'customer_export_'.now()->format('Ymd_His').'.csv', ['Content-Type' => AbstractExportService::CSV_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(PersonExportRequest $request): JsonResponse {
         $miniGridName = $request->input('miniGrid');
         $villageName = $request->input('village');
         $deviceType = $request->input('deviceType');

--- a/src/backend/app/Http/Controllers/SettingsExportController.php
+++ b/src/backend/app/Http/Controllers/SettingsExportController.php
@@ -2,34 +2,49 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\SettingsExportService;
 use App\Services\MainSettingsService;
+use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class SettingsExportController extends Controller {
     public function __construct(
         private MainSettingsService $mainSettingsService,
         private SettingsExportService $settingsExportService,
     ) {}
 
+    /**
+     * Export settings.
+     *
+     * Returns the main settings as JSON, or downloads them as an Excel or CSV file.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    #[QueryParameter('format', description: 'Export format.', type: "'json'|'excel'|'csv'", default: 'json')]
     public function download(Request $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'json');
 
         if ($format === 'excel') {
-            return $this->downloadExcel($request);
+            return $this->downloadExcel();
         }
 
         if ($format === 'csv') {
-            return $this->downloadCsv($request);
+            return $this->downloadCsv();
         }
 
-        return $this->downloadJson($request);
+        return $this->downloadJson();
     }
 
-    public function downloadExcel(Request $request): StreamedResponse {
+    public function downloadExcel(): StreamedResponse {
         $settings = $this->mainSettingsService->getAll()->first();
         $this->settingsExportService->setSettingsData($settings);
         $this->settingsExportService->createSpreadSheetFromTemplate($this->settingsExportService->getTemplatePath());
@@ -37,20 +52,20 @@ class SettingsExportController extends Controller {
         $this->settingsExportService->writeSettingsData();
         $pathToSpreadSheet = $this->settingsExportService->saveSpreadSheet();
 
-        return Storage::download($pathToSpreadSheet, 'settings_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'settings_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadCsv(Request $request): StreamedResponse {
+    public function downloadCsv(): StreamedResponse {
         $settings = $this->mainSettingsService->getAll()->first();
         $this->settingsExportService->setSettingsData($settings);
         $this->settingsExportService->setExportingData();
         $headers = ['Site Title', 'Company Name', 'Currency', 'Country', 'Language', 'VAT Energy', 'VAT Appliance', 'Usage Type', 'SMS Gateway ID', 'Created At', 'Updated At'];
         $csvPath = $this->settingsExportService->saveCsv($headers);
 
-        return Storage::download($csvPath, 'settings_export_'.now()->format('Ymd_His').'.csv');
+        return Storage::download($csvPath, 'settings_export_'.now()->format('Ymd_His').'.csv', ['Content-Type' => AbstractExportService::CSV_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(): JsonResponse {
         $settings = $this->mainSettingsService->getAll()->first();
         $this->settingsExportService->setSettingsData($settings);
         $jsonData = $this->settingsExportService->exportDataToArray();

--- a/src/backend/app/Http/Controllers/TransactionExportController.php
+++ b/src/backend/app/Http/Controllers/TransactionExportController.php
@@ -2,14 +2,19 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\TransactionExportRequest;
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\TransactionExportService;
 use App\Services\MainSettingsService;
 use App\Services\TransactionService;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class TransactionExportController {
     public function __construct(
         private TransactionService $transactionService,
@@ -17,7 +22,15 @@ class TransactionExportController {
         private MainSettingsService $mainSettingsService,
     ) {}
 
-    public function download(Request $request): StreamedResponse|JsonResponse {
+    /**
+     * Export transactions.
+     *
+     * Downloads transactions as an Excel or CSV file, or returns them as JSON.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    public function download(TransactionExportRequest $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'excel');
 
         if ($format === 'csv') {
@@ -31,9 +44,7 @@ class TransactionExportController {
         return $this->downloadExcel($request);
     }
 
-    public function downloadExcel(
-        Request $request,
-    ): StreamedResponse {
+    public function downloadExcel(TransactionExportRequest $request): StreamedResponse {
         $deviceType = $request->input('deviceType', 'all');
         $serialNumber = $request->input('serial_number');
         $tariffId = $request->input('tariff');
@@ -59,10 +70,10 @@ class TransactionExportController {
         $this->transactionExportService->writeTransactionData();
         $pathToSpreadSheet = $this->transactionExportService->saveSpreadSheet();
 
-        return Storage::download($pathToSpreadSheet, 'transaction_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'transaction_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadCsv(Request $request): StreamedResponse {
+    public function downloadCsv(TransactionExportRequest $request): StreamedResponse {
         $deviceType = $request->input('deviceType', 'all');
         $transactionProvider = $request->input('provider', 'all');
         $status = $request->input('status');
@@ -85,10 +96,10 @@ class TransactionExportController {
         $headers = ['Status', 'Payment Service', 'Customer', 'Device Serial Number', 'Device Type', 'Amount', 'Type', 'Date'];
         $csvPath = $this->transactionExportService->saveCsv($headers);
 
-        return Storage::download($csvPath, 'transaction_export_'.now()->format('Ymd_His').'.csv');
+        return Storage::download($csvPath, 'transaction_export_'.now()->format('Ymd_His').'.csv', ['Content-Type' => AbstractExportService::CSV_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(TransactionExportRequest $request): JsonResponse {
         $deviceType = $request->input('deviceType', 'all');
         $serialNumber = $request->input('serial_number');
         $transactionProvider = $request->input('provider', 'all');

--- a/src/backend/app/Http/Controllers/UserPermissionExportController.php
+++ b/src/backend/app/Http/Controllers/UserPermissionExportController.php
@@ -2,34 +2,49 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\ExportServices\AbstractExportService;
 use App\Services\ExportServices\UserPermissionExportService;
 use App\Services\UserService;
+use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\QueryParameter;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+#[Group('Export', 'Export data as Excel, CSV, or JSON.', weight: 11)]
 class UserPermissionExportController extends Controller {
     public function __construct(
         private UserService $userService,
         private UserPermissionExportService $userPermissionExportService,
     ) {}
 
+    /**
+     * Export users and permissions.
+     *
+     * Returns users with their roles and permissions as JSON, or downloads them as an Excel or CSV file.
+     *
+     * @throws AuthenticationException
+     * @throws AuthorizationException
+     */
+    #[QueryParameter('format', description: 'Export format.', type: "'json'|'excel'|'csv'", default: 'json')]
     public function download(Request $request): StreamedResponse|JsonResponse {
         $format = $request->input('format', 'json');
 
         if ($format === 'excel') {
-            return $this->downloadExcel($request);
+            return $this->downloadExcel();
         }
 
         if ($format === 'csv') {
-            return $this->downloadCsv($request);
+            return $this->downloadCsv();
         }
 
-        return $this->downloadJson($request);
+        return $this->downloadJson();
     }
 
-    public function downloadExcel(Request $request): StreamedResponse {
+    public function downloadExcel(): StreamedResponse {
         $users = $this->userService->getUsersWithRolesAndPermissions();
         $this->userPermissionExportService->createSpreadSheetFromTemplate($this->userPermissionExportService->getTemplatePath());
         $this->userPermissionExportService->setUserData($users);
@@ -37,10 +52,10 @@ class UserPermissionExportController extends Controller {
         $this->userPermissionExportService->writeUserPermissionData();
         $pathToSpreadSheet = $this->userPermissionExportService->saveSpreadSheet();
 
-        return Storage::download($pathToSpreadSheet, 'user_permission_export_'.now()->format('Ymd_His').'.xlsx');
+        return Storage::download($pathToSpreadSheet, 'user_permission_export_'.now()->format('Ymd_His').'.xlsx', ['Content-Type' => AbstractExportService::XLSX_CONTENT_TYPE]);
     }
 
-    public function downloadCsv(Request $request): StreamedResponse {
+    public function downloadCsv(): StreamedResponse {
         $users = $this->userService->getUsersWithRolesAndPermissions();
 
         $this->userPermissionExportService->setUserData($users);
@@ -48,10 +63,10 @@ class UserPermissionExportController extends Controller {
         $headers = ['Name', 'Email', 'Roles', 'Permissions', 'Created At'];
         $csvPath = $this->userPermissionExportService->saveCsv($headers);
 
-        return Storage::download($csvPath, 'user_permission_export_'.now()->format('Ymd_His').'.csv');
+        return Storage::download($csvPath, 'user_permission_export_'.now()->format('Ymd_His').'.csv', ['Content-Type' => AbstractExportService::CSV_CONTENT_TYPE]);
     }
 
-    public function downloadJson(Request $request): JsonResponse {
+    public function downloadJson(): JsonResponse {
         $users = $this->userService->getUsersWithRolesAndPermissions();
 
         $this->userPermissionExportService->setUserData($users);

--- a/src/backend/app/Http/Requests/DeviceExportRequest.php
+++ b/src/backend/app/Http/Requests/DeviceExportRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeviceExportRequest extends FormRequest {
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array {
+        return [
+            /*
+             * Export format.
+             *
+             * @default excel
+             */
+            'format' => ['nullable', 'in:excel,csv,json'],
+
+            /* Filter by mini-grid name. */
+            'miniGrid' => ['nullable', 'string'],
+
+            /* Filter by village name. */
+            'village' => ['nullable', 'string'],
+
+            /* Filter by device type. */
+            'deviceType' => ['nullable', 'in:meter,solar_home_system,e_bike'],
+
+            /* Filter by manufacturer name. */
+            'manufacturer' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/src/backend/app/Http/Requests/PersonExportRequest.php
+++ b/src/backend/app/Http/Requests/PersonExportRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PersonExportRequest extends FormRequest {
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array {
+        return [
+            /*
+             * Export format.
+             *
+             * @default excel
+             */
+            'format' => ['nullable', 'in:excel,csv,json'],
+
+            /* Filter by mini-grid name. */
+            'miniGrid' => ['nullable', 'string'],
+
+            /* Filter by village name. */
+            'village' => ['nullable', 'string'],
+
+            /* Filter by device type. */
+            'deviceType' => ['nullable', 'in:meter,solar_home_system,e_bike'],
+
+            /* Filter by activity: `true` = customers with a payment within the last 25 days, `false` = customers without one. */
+            'isActive' => ['nullable', 'in:true,false'],
+        ];
+    }
+}

--- a/src/backend/app/Http/Requests/TransactionExportRequest.php
+++ b/src/backend/app/Http/Requests/TransactionExportRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TransactionExportRequest extends FormRequest {
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array {
+        return [
+            /*
+             * Export format.
+             *
+             * @default excel
+             */
+            'format' => ['nullable', 'in:excel,csv,json'],
+
+            /*
+             * Filter by device type.
+             *
+             * @default all
+             */
+            'deviceType' => ['nullable', 'in:all,meter,solar_home_system,e_bike'],
+
+            /* Filter by device serial number. Ignored for the CSV format. */
+            'serial_number' => ['nullable', 'string'],
+
+            /* Filter by tariff id. Only applied to the Excel format. */
+            'tariff' => ['nullable', 'integer'],
+
+            /*
+             * Filter by transaction provider: `agent_transaction`, `cash_transaction`,
+             * `third_party_transaction`, or the alias of an installed payment provider plugin.
+             *
+             * @default all
+             */
+            'provider' => ['nullable', 'string'],
+
+            /* Filter by transaction status: `1` = approved, `-1` = rejected. */
+            'status' => ['nullable', 'integer'],
+
+            /* Include transactions created on or after this date. */
+            'from' => ['nullable', 'date'],
+
+            /* Include transactions created on or before this date. */
+            'to' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/src/backend/app/Services/ExportServices/AbstractExportService.php
+++ b/src/backend/app/Services/ExportServices/AbstractExportService.php
@@ -19,6 +19,9 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 abstract class AbstractExportService {
+    public const string XLSX_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    public const string CSV_CONTENT_TYPE = 'text/csv';
+
     protected IReader $reader;
     protected Worksheet $worksheet;
     protected Spreadsheet $spreadsheet;

--- a/src/backend/app/Utils/ScrambleExtensions/BinaryStreamedResponseToSchema.php
+++ b/src/backend/app/Utils/ScrambleExtensions/BinaryStreamedResponseToSchema.php
@@ -23,7 +23,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * binary formats such as xlsx. This extension documents streamed responses whose
  * literal `Content-Type` header is a binary mime type with a `format: binary`
  * string schema instead. Everything else (SSE, `text/csv`, JSON streams, or no
- * literal content type) falls through to the built-in extension by returning null.
+ * literal content type) falls through to the built-in extension by returning
+ * null.
+ *
  * https://github.com/dedoc/scramble/issues/1224
  */
 class BinaryStreamedResponseToSchema extends TypeToSchemaExtension {

--- a/src/backend/app/Utils/ScrambleExtensions/BinaryStreamedResponseToSchema.php
+++ b/src/backend/app/Utils/ScrambleExtensions/BinaryStreamedResponseToSchema.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Utils\ScrambleExtensions;
+
+use Dedoc\Scramble\Extensions\TypeToSchemaExtension;
+use Dedoc\Scramble\Support\Generator\Header;
+use Dedoc\Scramble\Support\Generator\Response;
+use Dedoc\Scramble\Support\Generator\Schema;
+use Dedoc\Scramble\Support\Generator\Types\StringType;
+use Dedoc\Scramble\Support\Type\Generic;
+use Dedoc\Scramble\Support\Type\KeyedArrayType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
+use Dedoc\Scramble\Support\Type\Literal\LiteralStringType;
+use Dedoc\Scramble\Support\Type\Type;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\BinaryFileResponseToSchema;
+use Dedoc\Scramble\Support\TypeToSchemaExtensions\StreamedResponseToSchema;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Scramble's built-in StreamedResponseToSchema documents every non-JSON, non-SSE
+ * streamed response body as a plain string, which is wrong for file downloads of
+ * binary formats such as xlsx. This extension documents streamed responses whose
+ * literal `Content-Type` header is a binary mime type with a `format: binary`
+ * string schema instead. Everything else (SSE, `text/csv`, JSON streams, or no
+ * literal content type) falls through to the built-in extension by returning null.
+ */
+class BinaryStreamedResponseToSchema extends TypeToSchemaExtension {
+    public function shouldHandle(Type $type): bool {
+        return $type instanceof Generic
+            && $type->isInstanceOf(StreamedResponse::class)
+            && count($type->templateTypes) === 3;
+    }
+
+    /**
+     * @param Generic $type
+     */
+    public function toResponse(Type $type): ?Response {
+        $contentType = $this->contentTypeFromHeaders($type->templateTypes[2 /* THeaders */]);
+
+        if ($contentType === null || in_array($contentType, BinaryFileResponseToSchema::$nonBinaryMimeTypes)) {
+            return null;
+        }
+
+        $statusType = $type->templateTypes[1 /* TStatus */];
+
+        if (!$statusType instanceof LiteralIntegerType) {
+            return null;
+        }
+
+        return Response::make($statusType->value)
+            ->setDescription('A streamed file download.')
+            ->setContent($contentType, Schema::fromType(new StringType()->format('binary')))
+            ->setHeaders([
+                'Transfer-Encoding' => new Header(
+                    required: true,
+                    schema: Schema::fromType(new StringType()->enum(['chunked'])),
+                ),
+            ]);
+    }
+
+    /**
+     * Mirrors the lookup StreamedResponseToSchema does internally (it is private
+     * there): a `Content-Type` entry with a literal string value in the headers
+     * array passed at the call site.
+     *
+     * @see StreamedResponseToSchema
+     */
+    private function contentTypeFromHeaders(Type $headersType): ?string {
+        if (!$headersType instanceof KeyedArrayType) {
+            return null;
+        }
+
+        foreach ($headersType->items as $item) {
+            if (is_string($item->key)
+                && Str::lower($item->key) === 'content-type'
+                && $item->value instanceof LiteralStringType) {
+                return $item->value->value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/backend/app/Utils/ScrambleExtensions/BinaryStreamedResponseToSchema.php
+++ b/src/backend/app/Utils/ScrambleExtensions/BinaryStreamedResponseToSchema.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * literal `Content-Type` header is a binary mime type with a `format: binary`
  * string schema instead. Everything else (SSE, `text/csv`, JSON streams, or no
  * literal content type) falls through to the built-in extension by returning null.
+ * https://github.com/dedoc/scramble/issues/1224
  */
 class BinaryStreamedResponseToSchema extends TypeToSchemaExtension {
     public function shouldHandle(Type $type): bool {

--- a/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
+++ b/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Utils\ScrambleExtensions;
+
+use Dedoc\Scramble\Infer\Extensions\Event\MethodCallEvent;
+use Dedoc\Scramble\Infer\Extensions\MethodReturnTypeExtension;
+use Dedoc\Scramble\Support\Type\ArrayType;
+use Dedoc\Scramble\Support\Type\Generic;
+use Dedoc\Scramble\Support\Type\Literal\LiteralIntegerType;
+use Dedoc\Scramble\Support\Type\ObjectType;
+use Dedoc\Scramble\Support\Type\StringType;
+use Dedoc\Scramble\Support\Type\Type;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemManager;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Scramble cannot see through `Storage::download(...)` (the facade resolves to
+ * FilesystemManager, whose `download` lives behind `__call`), so file-download
+ * endpoints would be documented as a generic JSON object instead of a file.
+ * This extension types those calls as the streamed response Scramble knows how
+ * to document; the response content type is picked up from a literal
+ * `Content-Type` header passed to `Storage::download()` at the call site.
+ */
+class StorageDownloadTypeInfer implements MethodReturnTypeExtension {
+    public function shouldHandle(ObjectType $type): bool {
+        return $type->isInstanceOf(FilesystemManager::class)
+            || $type->isInstanceOf(Filesystem::class);
+    }
+
+    public function getMethodReturnType(MethodCallEvent $event): ?Type {
+        if ($event->name !== 'download') {
+            return null;
+        }
+
+        return new Generic(StreamedResponse::class, [
+            new StringType(),
+            new LiteralIntegerType(200),
+            $event->getArg('headers', 2, new ArrayType()),
+        ]);
+    }
+}

--- a/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
+++ b/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * `download()` returns at runtime — carrying the literal headers from the call
  * site so the schema extensions can derive the response content type (and mark
  * binary formats accordingly, see BinaryStreamedResponseToSchema).
+ *
  * https://github.com/dedoc/scramble/discussions/1223
  */
 class StorageDownloadTypeInfer implements MethodReturnTypeExtension {

--- a/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
+++ b/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * `download()` returns at runtime — carrying the literal headers from the call
  * site so the schema extensions can derive the response content type (and mark
  * binary formats accordingly, see BinaryStreamedResponseToSchema).
+ * https://github.com/dedoc/scramble/discussions/1223
  */
 class StorageDownloadTypeInfer implements MethodReturnTypeExtension {
     public function shouldHandle(ObjectType $type): bool {

--- a/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
+++ b/src/backend/app/Utils/ScrambleExtensions/StorageDownloadTypeInfer.php
@@ -15,12 +15,18 @@ use Illuminate\Filesystem\FilesystemManager;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
- * Scramble cannot see through `Storage::download(...)` (the facade resolves to
- * FilesystemManager, whose `download` lives behind `__call`), so file-download
- * endpoints would be documented as a generic JSON object instead of a file.
- * This extension types those calls as the streamed response Scramble knows how
- * to document; the response content type is picked up from a literal
- * `Content-Type` header passed to `Storage::download()` at the call site.
+ * `download()` is only implemented on the concrete FilesystemAdapter, and no
+ * static path leads Scramble there: the `Storage` facade resolves to
+ * FilesystemManager, which forwards unknown methods to the default disk via
+ * `__call` (declared `@return mixed`), and `Storage::disk()` is typed as the
+ * Filesystem contract, which does not declare `download()` either. With no
+ * reachable method definition to infer a return type from, Scramble documents
+ * these endpoints as a generic JSON object instead of a file download.
+ *
+ * This extension supplies the missing return type — the StreamedResponse that
+ * `download()` returns at runtime — carrying the literal headers from the call
+ * site so the schema extensions can derive the response content type (and mark
+ * binary formats accordingly, see BinaryStreamedResponseToSchema).
  */
 class StorageDownloadTypeInfer implements MethodReturnTypeExtension {
     public function shouldHandle(ObjectType $type): bool {

--- a/src/backend/config/scramble.php
+++ b/src/backend/config/scramble.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Utils\ScrambleExtensions\ApiResourceTypeToSchema;
+use App\Utils\ScrambleExtensions\BinaryStreamedResponseToSchema;
 use App\Utils\ScrambleExtensions\StorageDownloadTypeInfer;
 use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
 
@@ -163,6 +164,7 @@ DESC,
 
     'extensions' => [
         ApiResourceTypeToSchema::class,
+        BinaryStreamedResponseToSchema::class,
         StorageDownloadTypeInfer::class,
     ],
 ];

--- a/src/backend/config/scramble.php
+++ b/src/backend/config/scramble.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Utils\ScrambleExtensions\ApiResourceTypeToSchema;
+use App\Utils\ScrambleExtensions\StorageDownloadTypeInfer;
 use Dedoc\Scramble\Http\Middleware\RestrictedDocsAccess;
 
 return [
@@ -162,5 +163,6 @@ DESC,
 
     'extensions' => [
         ApiResourceTypeToSchema::class,
+        StorageDownloadTypeInfer::class,
     ],
 ];


### PR DESCRIPTION
Closes #1557 

<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

The PR attempts to better group all export endpoints and refactor the export endpoint request/response entities to provide better context to the docs. 

### Are there any other side effects of this change that we should be aware of?

A new scramble type extension was created to better represent `StreamedResponse` 

<img width="1894" height="872" alt="Screenshot 2026-07-13 at 9 39 17 AM" src="https://github.com/user-attachments/assets/16534f6c-4958-47c6-96cb-f1368037d50f" />



### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
