### PR TITLE
Use `DeviceType` and `MappingStatus` enums

### DIFF
--- a/collections/AppliancePersons/Get specific AppliancePerson.bru
+++ b/collections/AppliancePersons/Get specific AppliancePerson.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get specific AppliancePerson
+  type: http
+  seq: 34
+}
+
+get {
+  url: {{mpm_backend_url}}/api/appliances/person/people/1655
+  body: none
+  auth: inherit
+}

--- a/collections/AppliancePersons/folder.bru
+++ b/collections/AppliancePersons/folder.bru
@@ -1,6 +1,6 @@
 meta {
-  name: Appliances
-  seq: 46
+  name: AppliancePersons
+  seq: 45
 }
 
 auth {

--- a/collections/Devices/Get Device by Serial Number.bru
+++ b/collections/Devices/Get Device by Serial Number.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Device by Serial Number
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{mpm_backend_url}}/api/devices?serial=121
+  body: none
+  auth: inherit
+}
+
+params:query {
+  serial: 121
+}

--- a/collections/Devices/Get Devices by Serial Number.bru
+++ b/collections/Devices/Get Devices by Serial Number.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Get Device by Serial Number
+  name: Get Devices by Serial Number
   type: http
   seq: 2
 }

--- a/collections/Get specific Customer.bru
+++ b/collections/Get specific Customer.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{mpm_backend_url}}/api/people/5
+  url: {{mpm_backend_url}}/api/people/1655
   body: none
   auth: inherit
 }

--- a/src/backend/app/Enums/DeviceType.php
+++ b/src/backend/app/Enums/DeviceType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use App\Models\EBike;
+use App\Models\Meter\Meter;
+use App\Models\SolarHomeSystem;
+
+// The docblocks below are public and get rendered into the API docs.
+
+/**
+ * The kind of unit a `Device` record wraps.
+ * Stored in `devices.device_type` and used as the morph name of the device relation,
+ * so the values are derived from the models' `RELATION_NAME` constants.
+ */
+enum DeviceType: string {
+    /** Smart Meter */
+    case Meter = Meter::RELATION_NAME;
+    /** Solar Home System (SHS) */
+    case SolarHomeSystem = SolarHomeSystem::RELATION_NAME;
+    /** E-Bike */
+    case EBike = EBike::RELATION_NAME;
+}

--- a/src/backend/app/Enums/ManufacturerMappingStatus.php
+++ b/src/backend/app/Enums/ManufacturerMappingStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+// The docblocks below are public and get rendered into the API docs.
+
+/**
+ * Outcome of the last manufacturer mapping check of a device.
+ */
+enum ManufacturerMappingStatus: string {
+    /** Mapping has never been checked, or the last check errored. */
+    case Unknown = 'unknown';
+    /** The unit is known/mapped on the manufacturer side. */
+    case Mapped = 'mapped';
+    /** The manufacturer API responded that the unit is not mapped. */
+    case NotMapped = 'not_mapped';
+    /** The device's manufacturer exposes no device management API. */
+    case Unsupported = 'unsupported';
+}

--- a/src/backend/app/Http/Controllers/DeviceController.php
+++ b/src/backend/app/Http/Controllers/DeviceController.php
@@ -2,16 +2,14 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\DeviceType;
-use App\Enums\ManufacturerMappingStatus;
 use App\Events\NewLogEvent;
+use App\Http\Requests\DeviceListRequest;
 use App\Http\Requests\UpdateDeviceRequest;
 use App\Http\Resources\ApiResource;
 use App\Http\Resources\DeviceMappingResource;
 use App\Models\Device;
 use App\Services\DeviceService;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 
 class DeviceController extends Controller {
     public function __construct(private DeviceService $deviceService) {}
@@ -24,31 +22,10 @@ class DeviceController extends Controller {
      *
      * The endpoint returns device owner and type-specific details.
      */
-    public function index(Request $request): ApiResource {
-        $request->validate([
-            // Filter by device type.
-            'device_type' => ['sometimes', Rule::enum(DeviceType::class)],
-            // Filter by the appliance the device belongs to.
-            'appliance_id' => ['sometimes', 'integer'],
-            // When true, only devices not assigned to a customer are returned.
-            'unassigned' => ['sometimes', 'boolean'],
-            // Filter by (partial) device serial number.
-            'serial' => ['sometimes', 'string'],
-            // Filter by the outcome of the last manufacturer mapping check.
-            'manufacturer_mapping_status' => ['sometimes', Rule::enum(ManufacturerMappingStatus::class)],
-            // The number of items per page.
-            'per_page' => ['sometimes', 'integer'],
-        ]);
-
-        $filters = [
-            'device_type' => $request->enum('device_type', DeviceType::class),
-            'appliance_id' => $request->integer('appliance_id'),
-            'unassigned' => $request->boolean('unassigned'),
-            'serial' => $request->string('serial')->toString(),
-            'manufacturer_mapping_status' => $request->enum('manufacturer_mapping_status', ManufacturerMappingStatus::class),
-        ];
-
-        return ApiResource::make($this->deviceService->getAll($request->integer('per_page', 15), $filters));
+    public function index(DeviceListRequest $request): ApiResource {
+        return ApiResource::make(
+            $this->deviceService->getAll($request->integer('per_page', 15), $request->filters())
+        );
     }
 
     /**

--- a/src/backend/app/Http/Controllers/DeviceController.php
+++ b/src/backend/app/Http/Controllers/DeviceController.php
@@ -17,7 +17,7 @@ class DeviceController extends Controller {
     /**
      * List devices.
      *
-     * List of devices with optional filter parameters. Calling the endpoints without filter 
+     * List of devices with optional filter parameters. Calling the endpoints without filter
      * parameters returns all devices.
      *
      * The endpoint returns device owner and type-specific details.

--- a/src/backend/app/Http/Controllers/DeviceController.php
+++ b/src/backend/app/Http/Controllers/DeviceController.php
@@ -19,8 +19,8 @@ class DeviceController extends Controller {
     /**
      * List devices.
      *
-     * Paginated list of devices with optional filter paramenters.
-     * Call the endpoints without filter parameters returns all devices.
+     * List of devices with optional filter parameters. Calling the endpoints without filter 
+     * parameters returns all devices.
      *
      * The endpoint returns device owner and type-specific details.
      */

--- a/src/backend/app/Http/Controllers/DeviceController.php
+++ b/src/backend/app/Http/Controllers/DeviceController.php
@@ -16,6 +16,14 @@ use Illuminate\Validation\Rule;
 class DeviceController extends Controller {
     public function __construct(private DeviceService $deviceService) {}
 
+    /**
+     * List devices.
+     *
+     * Paginated list of devices with optional filter paramenters.
+     * Call the endpoints without filter parameters returns all devices.
+     *
+     * The endpoint returns device owner and type-specific details.
+     */
     public function index(Request $request): ApiResource {
         $request->validate([
             // Filter by device type.
@@ -43,10 +51,16 @@ class DeviceController extends Controller {
         return ApiResource::make($this->deviceService->getAll($request->integer('per_page', 15), $filters));
     }
 
+    /**
+     * Update a device.
+     *
+     * Primarily used to assign a device to another customer.
+     * The owner change is also written to the audit log.
+     */
     public function update(Device $device, UpdateDeviceRequest $request): ApiResource {
         $creatorId = auth('api')->user()->id;
         $previousOwner = $device->person_id;
-        $newOwner = $request->input('person_id');
+        $newOwner = $request->integer('person_id');
         $deviceData = $request->validated();
         $updatedDevice = $this->deviceService->update($device, $deviceData);
         event(new NewLogEvent([
@@ -69,6 +83,12 @@ class DeviceController extends Controller {
         return DeviceMappingResource::make($this->deviceService->refreshManufacturerMapping($device));
     }
 
+    /**
+     * Update device locations.
+     *
+     * Accepts a list of `{serial_number, lat, lon}` items and moves each
+     * device to the given coordinates. Changes are also written to the audit log.
+     */
     public function updateGeoInformation(Request $request): ApiResource {
         $creatorId = auth('api')->user()->id;
         $devices = $request->all();

--- a/src/backend/app/Http/Controllers/DeviceController.php
+++ b/src/backend/app/Http/Controllers/DeviceController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\DeviceType;
+use App\Enums\ManufacturerMappingStatus;
 use App\Events\NewLogEvent;
 use App\Http\Requests\UpdateDeviceRequest;
 use App\Http\Resources\ApiResource;
@@ -9,15 +11,36 @@ use App\Http\Resources\DeviceMappingResource;
 use App\Models\Device;
 use App\Services\DeviceService;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class DeviceController extends Controller {
     public function __construct(private DeviceService $deviceService) {}
 
     public function index(Request $request): ApiResource {
-        $limit = $request->integer('per_page', 15);
-        $filters = $request->only(['device_type', 'appliance_id', 'unassigned', 'serial', 'manufacturer_mapping_status']);
+        $request->validate([
+            // Filter by device type.
+            'device_type' => ['sometimes', Rule::enum(DeviceType::class)],
+            // Filter by the appliance the device belongs to.
+            'appliance_id' => ['sometimes', 'integer'],
+            // When true, only devices not assigned to a customer are returned.
+            'unassigned' => ['sometimes', 'boolean'],
+            // Filter by (partial) device serial number.
+            'serial' => ['sometimes', 'string'],
+            // Filter by the outcome of the last manufacturer mapping check.
+            'manufacturer_mapping_status' => ['sometimes', Rule::enum(ManufacturerMappingStatus::class)],
+            // The number of items per page.
+            'per_page' => ['sometimes', 'integer'],
+        ]);
 
-        return ApiResource::make($this->deviceService->getAll($limit, $filters));
+        $filters = [
+            'device_type' => $request->enum('device_type', DeviceType::class),
+            'appliance_id' => $request->integer('appliance_id'),
+            'unassigned' => $request->boolean('unassigned'),
+            'serial' => $request->string('serial')->toString(),
+            'manufacturer_mapping_status' => $request->enum('manufacturer_mapping_status', ManufacturerMappingStatus::class),
+        ];
+
+        return ApiResource::make($this->deviceService->getAll($request->integer('per_page', 15), $filters));
     }
 
     public function update(Device $device, UpdateDeviceRequest $request): ApiResource {

--- a/src/backend/app/Http/Requests/DeviceImportRequest.php
+++ b/src/backend/app/Http/Requests/DeviceImportRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\DeviceType;
 use App\Services\ImportServices\DeviceImportItem;
 use App\Services\ImportServices\DeviceInfoItem;
 use App\Services\ImportServices\MeterTypeItem;
@@ -48,7 +49,7 @@ class DeviceImportRequest extends FormRequest {
                 customer: $item['customer'] ?? null,
                 deviceInfo: new DeviceInfoItem(
                     serialNumber: $info['serial_number'],
-                    type: $info['type'] ?? 'meter',
+                    type: $info['type'] ?? DeviceType::Meter->value,
                     manufacturer: $info['manufacturer'] ?? null,
                     meterType: $meterType === null ? null : new MeterTypeItem(
                         online: (bool) ($meterType['online'] ?? false),

--- a/src/backend/app/Http/Requests/DeviceListRequest.php
+++ b/src/backend/app/Http/Requests/DeviceListRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\DeviceType;
+use App\Enums\ManufacturerMappingStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DeviceListRequest extends FormRequest {
+    public function authorize(): bool {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array {
+        return [
+            // Filter by device type.
+            'device_type' => ['sometimes', Rule::enum(DeviceType::class)],
+            // Filter by the appliance the device belongs to.
+            'appliance_id' => ['sometimes', 'integer'],
+            // When true, only devices not assigned to a customer are returned.
+            'unassigned' => ['sometimes', 'boolean'],
+            // Filter by (partial) device serial number.
+            'serial' => ['sometimes', 'string'],
+            // Filter by the outcome of the last manufacturer mapping check.
+            'manufacturer_mapping_status' => ['sometimes', Rule::enum(ManufacturerMappingStatus::class)],
+            // The number of items per page.
+            'per_page' => ['sometimes', 'integer'],
+        ];
+    }
+
+    /**
+     * @return array{device_type: DeviceType|null, appliance_id: int, unassigned: bool, serial: string, manufacturer_mapping_status: ManufacturerMappingStatus|null}
+     */
+    public function filters(): array {
+        return [
+            'device_type' => $this->enum('device_type', DeviceType::class),
+            'appliance_id' => $this->integer('appliance_id'),
+            'unassigned' => $this->boolean('unassigned'),
+            'serial' => $this->string('serial')->toString(),
+            'manufacturer_mapping_status' => $this->enum('manufacturer_mapping_status', ManufacturerMappingStatus::class),
+        ];
+    }
+}

--- a/src/backend/app/Http/Requests/UpdateDeviceRequest.php
+++ b/src/backend/app/Http/Requests/UpdateDeviceRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\DeviceType;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateDeviceRequest extends FormRequest {
     /**
@@ -15,13 +17,13 @@ class UpdateDeviceRequest extends FormRequest {
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, array<int, string>>
+     * @return array<string, array<int, mixed>>
      */
     public function rules(): array {
         return [
             'id' => ['required', 'numeric'],
             'person_id' => ['required', 'numeric'],
-            'device_type' => ['required'],
+            'device_type' => ['required', Rule::enum(DeviceType::class)],
             'device_serial' => ['required'],
             'device_id' => ['required', 'numeric'],
         ];

--- a/src/backend/app/Models/Device.php
+++ b/src/backend/app/Models/Device.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ManufacturerMappingStatus;
 use App\Models\Address\Address;
 use App\Models\Base\BaseModel;
 use App\Models\Meter\Meter;
@@ -24,7 +25,7 @@ use Illuminate\Support\Carbon;
  * @property      string                       $device_type
  * @property      int                          $device_id
  * @property      string                       $device_serial
- * @property      string                       $manufacturer_mapping_status
+ * @property      ManufacturerMappingStatus    $manufacturer_mapping_status
  * @property      Carbon|null                  $manufacturer_mapping_checked_at
  * @property      Carbon|null                  $created_at
  * @property      Carbon|null                  $updated_at
@@ -43,17 +44,9 @@ class Device extends BaseModel {
 
     public const RELATION_NAME = 'device';
 
-    /** Mapping has never been checked, or the last check errored. */
-    public const MAPPING_STATUS_UNKNOWN = 'unknown';
-    /** The unit is known/mapped on the manufacturer side. */
-    public const MAPPING_STATUS_MAPPED = 'mapped';
-    /** The manufacturer API responded that the unit is not mapped. */
-    public const MAPPING_STATUS_NOT_MAPPED = 'not_mapped';
-    /** The device's manufacturer exposes no device management API. */
-    public const MAPPING_STATUS_UNSUPPORTED = 'unsupported';
-
     /** @var array<string, string> */
     protected $casts = [
+        'manufacturer_mapping_status' => ManufacturerMappingStatus::class,
         'manufacturer_mapping_checked_at' => 'datetime',
     ];
 

--- a/src/backend/app/Models/Meter/Meter.php
+++ b/src/backend/app/Models/Meter/Meter.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Meter;
 
+use App\Enums\DeviceType;
 use App\Models\AccessRate\AccessRate;
 use App\Models\AccessRate\AccessRatePayment;
 use App\Models\Base\BaseModel;
@@ -106,7 +107,7 @@ class Meter extends BaseModel {
             'device_id',
             'id',
             'id'
-        )->where('device_type', 'meter');
+        )->where('device_type', DeviceType::Meter);
     }
 
     /** @return HasMany<MeterConsumption, $this> */

--- a/src/backend/app/Models/SolarHomeSystem.php
+++ b/src/backend/app/Models/SolarHomeSystem.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\DeviceType;
 use App\Models\Base\BaseModel;
 use Database\Factories\SolarHomeSystemFactory;
 use Illuminate\Database\Eloquent\Collection;
@@ -74,6 +75,6 @@ class SolarHomeSystem extends BaseModel {
             'device_id',         // Foreign key on Token table that points to Device.id
             'id',               // Local key on SolarHomeSystem table
             'id'                // Local key on Device table
-        )->where('device_type', 'solar_home_system'); // Ensure we only get SHS devices
+        )->where('device_type', DeviceType::SolarHomeSystem);
     }
 }

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackPublicController.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Http/Controllers/PaystackPublicController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\PaystackPaymentProvider\Http\Controllers;
 
+use App\Enums\DeviceType;
 use App\Plugins\PaystackPaymentProvider\Http\Requests\PublicPaymentRequest;
 use App\Plugins\PaystackPaymentProvider\Models\PaystackTransaction;
 use App\Plugins\PaystackPaymentProvider\Modules\Api\PaystackApiService;
@@ -66,11 +67,11 @@ class PaystackPublicController extends Controller {
             }
 
             $validatedData = $request->validated();
-            $deviceType = $validatedData['device_type'] ?? 'meter';
+            $deviceType = $validatedData['device_type'] ?? DeviceType::Meter->value;
             $deviceSerial = $validatedData['device_serial'];
 
             // Get customer ID based on device type
-            if ($deviceType === 'solar_home_system') {
+            if ($deviceType === DeviceType::SolarHomeSystem->value) {
                 $customerId = $this->transactionService->getCustomerIdBySHSSerial($deviceSerial);
             } else {
                 $customerId = $this->transactionService->getCustomerIdByMeterSerial($deviceSerial);
@@ -228,7 +229,7 @@ class PaystackPublicController extends Controller {
             }
 
             $deviceSerial = $request->input('device_serial') ?? $request->input('meter_serial');
-            $deviceType = $request->input('device_type', 'meter');
+            $deviceType = $request->string('device_type', DeviceType::Meter->value)->toString();
 
             if (!$deviceSerial) {
                 return response()->json(['error' => 'Device serial required'], 400);
@@ -248,7 +249,7 @@ class PaystackPublicController extends Controller {
                 'company_hash' => $companyHash,
                 'company_id' => $companyId,
                 'device_serial' => $request->input('device_serial') ?? $request->input('meter_serial'),
-                'device_type' => $request->input('device_type', 'meter'),
+                'device_type' => $request->string('device_type', DeviceType::Meter->value)->toString(),
             ]);
 
             return response()->json(['error' => 'Failed to validate device'], 500);

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Http/Requests/PublicPaymentRequest.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Http/Requests/PublicPaymentRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Plugins\PaystackPaymentProvider\Http\Requests;
 
+use App\Enums\DeviceType;
 use App\Plugins\PaystackPaymentProvider\Models\PaystackTransaction;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 use Ramsey\Uuid\Uuid;
 
 class PublicPaymentRequest extends FormRequest {
@@ -14,14 +16,14 @@ class PublicPaymentRequest extends FormRequest {
     }
 
     /**
-     * @return array<string, array<int, string|int>>
+     * @return array<string, array<int, mixed>>
      */
     public function rules(): array {
         $supportedCurrencies = config('paystack-payment-provider.currency.supported', ['NGN', 'GHS', 'KES', 'ZAR']);
 
         return [
             'device_serial' => ['required', 'string', 'min:3', 'max:50'],
-            'device_type' => ['nullable', 'string', 'in:meter,solar_home_system,e_bike'],
+            'device_type' => ['nullable', 'string', Rule::enum(DeviceType::class)],
             'amount' => [
                 'required',
                 'numeric',
@@ -62,7 +64,7 @@ class PublicPaymentRequest extends FormRequest {
             'amount' => $validated['amount'],
             'currency' => $validated['currency'],
             'serial_id' => $validated['device_serial'],
-            'device_type' => $validated['device_type'] ?? 'meter',
+            'device_type' => $validated['device_type'] ?? DeviceType::Meter->value,
             'customer_id' => 0, // Public payment
             'order_id' => Uuid::uuid4()->toString(),
             'reference_id' => Uuid::uuid4()->toString(),

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Http/Requests/TransactionInitializeRequest.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Http/Requests/TransactionInitializeRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Plugins\PaystackPaymentProvider\Http\Requests;
 
+use App\Enums\DeviceType;
 use App\Plugins\PaystackPaymentProvider\Models\PaystackTransaction;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 use Ramsey\Uuid\Uuid;
 
 class TransactionInitializeRequest extends FormRequest {
@@ -14,7 +16,7 @@ class TransactionInitializeRequest extends FormRequest {
     }
 
     /**
-     * @return array<string, array<int, string>>
+     * @return array<string, array<int, mixed>>
      */
     public function rules(): array {
         return [
@@ -22,7 +24,7 @@ class TransactionInitializeRequest extends FormRequest {
             'device_serial' => ['required', 'string'],
             'customer_id' => ['required', 'integer'],
             'currency' => ['string', 'in:NGN,GHS,KES'],
-            'device_type' => ['string', 'in:meter,solar_home_system'],
+            'device_type' => ['string', Rule::in([DeviceType::Meter->value, DeviceType::SolarHomeSystem->value])],
         ];
     }
 

--- a/src/backend/app/Plugins/PaystackPaymentProvider/Services/PaystackTransactionService.php
+++ b/src/backend/app/Plugins/PaystackPaymentProvider/Services/PaystackTransactionService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\PaystackPaymentProvider\Services;
 
+use App\Enums\DeviceType;
 use App\Jobs\ProcessPayment;
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
@@ -236,8 +237,8 @@ class PaystackTransactionService extends AbstractPaymentAggregatorTransactionSer
         return $shs !== null;
     }
 
-    public function validateDeviceSerial(string $serialId, string $deviceType = 'meter'): bool {
-        if ($deviceType === 'solar_home_system') {
+    public function validateDeviceSerial(string $serialId, string $deviceType = DeviceType::Meter->value): bool {
+        if ($deviceType === DeviceType::SolarHomeSystem->value) {
             return $this->validateSHSSerial($serialId);
         }
 

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Http/Controllers/PesapalPublicController.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Http/Controllers/PesapalPublicController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\PesapalPaymentProvider\Http\Controllers;
 
+use App\Enums\DeviceType;
 use App\Plugins\PesapalPaymentProvider\Http\Requests\PublicPaymentRequest;
 use App\Plugins\PesapalPaymentProvider\Models\PesapalTransaction;
 use App\Plugins\PesapalPaymentProvider\Services\PesapalCompanyHashService;
@@ -62,10 +63,10 @@ class PesapalPublicController extends Controller {
             }
 
             $validatedData = $request->validated();
-            $deviceType = $validatedData['device_type'] ?? 'meter';
+            $deviceType = $validatedData['device_type'] ?? DeviceType::Meter->value;
             $deviceSerial = $validatedData['device_serial'];
 
-            if ($deviceType === 'solar_home_system') {
+            if ($deviceType === DeviceType::SolarHomeSystem->value) {
                 $customerId = $this->transactionService->getCustomerIdBySHSSerial($deviceSerial);
             } else {
                 $customerId = $this->transactionService->getCustomerIdByMeterSerial($deviceSerial);
@@ -225,7 +226,7 @@ class PesapalPublicController extends Controller {
             }
 
             $deviceSerial = $request->input('device_serial') ?? $request->input('meter_serial');
-            $deviceType = $request->input('device_type', 'meter');
+            $deviceType = $request->string('device_type', DeviceType::Meter->value)->toString();
 
             if (!$deviceSerial) {
                 return response()->json(['error' => 'Device serial required'], 400);
@@ -244,7 +245,7 @@ class PesapalPublicController extends Controller {
                 'company_hash' => $companyHash,
                 'company_id' => $companyId,
                 'device_serial' => $request->input('device_serial') ?? $request->input('meter_serial'),
-                'device_type' => $request->input('device_type', 'meter'),
+                'device_type' => $request->string('device_type', DeviceType::Meter->value)->toString(),
             ]);
 
             return response()->json(['error' => 'Failed to validate device'], 500);

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Http/Requests/PublicPaymentRequest.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Http/Requests/PublicPaymentRequest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Plugins\PesapalPaymentProvider\Http\Requests;
 
+use App\Enums\DeviceType;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PublicPaymentRequest extends FormRequest {
     public function authorize(): bool {
@@ -12,12 +14,12 @@ class PublicPaymentRequest extends FormRequest {
     }
 
     /**
-     * @return array<string, array<int, string|int>>
+     * @return array<string, array<int, mixed>>
      */
     public function rules(): array {
         return [
             'device_serial' => ['required', 'string', 'min:3', 'max:50'],
-            'device_type' => ['nullable', 'string', 'in:meter,solar_home_system,e_bike'],
+            'device_type' => ['nullable', 'string', Rule::enum(DeviceType::class)],
             'amount' => [
                 'required',
                 'numeric',

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Http/Requests/TransactionInitializeRequest.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Http/Requests/TransactionInitializeRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Plugins\PesapalPaymentProvider\Http\Requests;
 
+use App\Enums\DeviceType;
 use App\Plugins\PesapalPaymentProvider\Models\PesapalTransaction;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 use Ramsey\Uuid\Uuid;
 
 class TransactionInitializeRequest extends FormRequest {
@@ -14,7 +16,7 @@ class TransactionInitializeRequest extends FormRequest {
     }
 
     /**
-     * @return array<string, array<int, string>>
+     * @return array<string, array<int, mixed>>
      */
     public function rules(): array {
         $supportedCurrencies = config('pesapal-payment-provider.currency.supported', ['KES', 'UGX', 'TZS', 'USD']);
@@ -24,7 +26,7 @@ class TransactionInitializeRequest extends FormRequest {
             'device_serial' => ['required', 'string'],
             'customer_id' => ['required', 'integer'],
             'currency' => ['nullable', 'string', 'in:'.implode(',', $supportedCurrencies)],
-            'device_type' => ['nullable', 'string', 'in:meter,solar_home_system'],
+            'device_type' => ['nullable', 'string', Rule::in([DeviceType::Meter->value, DeviceType::SolarHomeSystem->value])],
         ];
     }
 

--- a/src/backend/app/Plugins/PesapalPaymentProvider/Services/PesapalTransactionService.php
+++ b/src/backend/app/Plugins/PesapalPaymentProvider/Services/PesapalTransactionService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\PesapalPaymentProvider\Services;
 
+use App\Enums\DeviceType;
 use App\Jobs\ProcessPayment;
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
@@ -296,8 +297,8 @@ class PesapalTransactionService extends AbstractPaymentAggregatorTransactionServ
         return $shs !== null;
     }
 
-    public function validateDeviceSerial(string $serialId, string $deviceType = 'meter'): bool {
-        if ($deviceType === 'solar_home_system') {
+    public function validateDeviceSerial(string $serialId, string $deviceType = DeviceType::Meter->value): bool {
+        if ($deviceType === DeviceType::SolarHomeSystem->value) {
             return $this->validateSHSSerial($serialId);
         }
 

--- a/src/backend/app/Plugins/Prospect/Services/ProspectInstallationTransformer.php
+++ b/src/backend/app/Plugins/Prospect/Services/ProspectInstallationTransformer.php
@@ -2,6 +2,7 @@
 
 namespace App\Plugins\Prospect\Services;
 
+use App\Enums\DeviceType;
 use App\Models\Address\Address;
 use App\Models\AppliancePerson;
 use App\Models\DatabaseProxy;
@@ -217,10 +218,9 @@ class ProspectInstallationTransformer {
      * Map device type to device category.
      */
     private function mapDeviceCategory(string $deviceType): string {
-        return match ($deviceType) {
-            'meter' => 'meter',
-            'solar_home_system' => 'solar_home_system',
-            'e_bike' => 'other_production_use',
+        return match (DeviceType::tryFrom($deviceType)) {
+            DeviceType::Meter => 'meter',
+            DeviceType::SolarHomeSystem => 'solar_home_system',
             default => 'other_production_use',
         };
     }
@@ -229,7 +229,7 @@ class ProspectInstallationTransformer {
      * Map connection type to Prospect usage_category enum (household, institutional, commercial).
      */
     private function mapUsageCategory(Device $device, mixed $deviceData): ?string {
-        if ($device->device_type === 'meter' && $deviceData instanceof Meter) {
+        if ($device->device_type === DeviceType::Meter->value && $deviceData instanceof Meter) {
             $deviceData->load('connectionType');
             $category = $deviceData->connectionType?->name;
         } else {
@@ -265,7 +265,7 @@ class ProspectInstallationTransformer {
             return null;
         }
 
-        if ($device->device_type === 'meter' && $deviceData instanceof Meter) {
+        if ($device->device_type === DeviceType::Meter->value && $deviceData instanceof Meter) {
             $subConnectionType = SubConnectionType::query()
                 ->where('connection_type_id', $deviceData->connection_type_id)
                 ->first();

--- a/src/backend/app/Plugins/SafaricomKePaymentProvider/Http/Controllers/SafaricomTransactionController.php
+++ b/src/backend/app/Plugins/SafaricomKePaymentProvider/Http/Controllers/SafaricomTransactionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\SafaricomKePaymentProvider\Http\Controllers;
 
+use App\Enums\DeviceType;
 use App\Plugins\SafaricomKePaymentProvider\Http\Requests\SafaricomSTKPushRequest;
 use App\Plugins\SafaricomKePaymentProvider\Http\Resources\SafaricomTransactionResource;
 use App\Plugins\SafaricomKePaymentProvider\Models\SafaricomTransaction;
@@ -11,6 +12,7 @@ use App\Plugins\SafaricomKePaymentProvider\Services\SafaricomTransactionService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Validation\Rule;
 
 class SafaricomTransactionController extends Controller {
     public function __construct(
@@ -38,10 +40,10 @@ class SafaricomTransactionController extends Controller {
     public function validateDevice(Request $request): JsonResponse {
         $request->validate([
             'device_serial' => ['required', 'string', 'min:3', 'max:100'],
-            'device_type' => ['nullable', 'string', 'in:meter,solar_home_system'],
+            'device_type' => ['nullable', 'string', Rule::in([DeviceType::Meter->value, DeviceType::SolarHomeSystem->value])],
         ]);
         $deviceSerial = (string) $request->input('device_serial');
-        $deviceType = (string) ($request->input('device_type') ?? 'meter');
+        $deviceType = (string) ($request->input('device_type') ?? DeviceType::Meter->value);
 
         $isValid = $this->transactionService->validateDeviceSerial($deviceSerial, $deviceType);
         $customerId = $isValid
@@ -59,7 +61,7 @@ class SafaricomTransactionController extends Controller {
     public function initiateStkPush(SafaricomSTKPushRequest $request): JsonResponse {
         $data = $request->validated();
         $serialId = $data['device_serial'] ?? ($data['serial_id'] ?? null);
-        $deviceType = (string) ($data['device_type'] ?? 'meter');
+        $deviceType = (string) ($data['device_type'] ?? DeviceType::Meter->value);
 
         if (!$serialId || !$this->transactionService->validateDeviceSerial((string) $serialId, $deviceType)) {
             return response()->json([

--- a/src/backend/app/Plugins/SafaricomKePaymentProvider/Http/Requests/SafaricomSTKPushRequest.php
+++ b/src/backend/app/Plugins/SafaricomKePaymentProvider/Http/Requests/SafaricomSTKPushRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Plugins\SafaricomKePaymentProvider\Http\Requests;
 
+use App\Enums\DeviceType;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class SafaricomSTKPushRequest extends FormRequest {
     public function authorize(): bool {
@@ -10,13 +12,13 @@ class SafaricomSTKPushRequest extends FormRequest {
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return array<string, list<mixed>>
      */
     public function rules(): array {
         return [
             'amount' => ['required', 'numeric', 'min:1', 'max:150000'],
             'phone_number' => ['required', 'string', 'min:9', 'max:15'],
-            'device_type' => ['required', 'string', 'in:meter,solar_home_system'],
+            'device_type' => ['required', 'string', Rule::in([DeviceType::Meter->value, DeviceType::SolarHomeSystem->value])],
             'device_serial' => ['required', 'string', 'min:3', 'max:100'],
             'account_reference' => ['nullable', 'string', 'max:50'],
             'transaction_desc' => ['nullable', 'string', 'max:50'],

--- a/src/backend/app/Plugins/SafaricomKePaymentProvider/Services/SafaricomTransactionService.php
+++ b/src/backend/app/Plugins/SafaricomKePaymentProvider/Services/SafaricomTransactionService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\SafaricomKePaymentProvider\Services;
 
+use App\Enums\DeviceType;
 use App\Jobs\ProcessPayment;
 use App\Models\Address\Address;
 use App\Models\Meter\Meter;
@@ -614,8 +615,8 @@ class SafaricomTransactionService extends AbstractPaymentAggregatorTransactionSe
             ->exists();
     }
 
-    public function validateDeviceSerial(string $serialId, string $deviceType = 'meter'): bool {
-        if ($deviceType === 'solar_home_system') {
+    public function validateDeviceSerial(string $serialId, string $deviceType = DeviceType::Meter->value): bool {
+        if ($deviceType === DeviceType::SolarHomeSystem->value) {
             return $this->validateSHSSerial($serialId);
         }
 
@@ -649,8 +650,8 @@ class SafaricomTransactionService extends AbstractPaymentAggregatorTransactionSe
         return $person ? (int) $person->id : null;
     }
 
-    public function getCustomerIdByDeviceSerial(string $serialId, string $deviceType = 'meter'): ?int {
-        return $deviceType === 'solar_home_system'
+    public function getCustomerIdByDeviceSerial(string $serialId, string $deviceType = DeviceType::Meter->value): ?int {
+        return $deviceType === DeviceType::SolarHomeSystem->value
             ? $this->getCustomerIdBySHSSerial($serialId)
             : $this->getCustomerIdByMeterSerial($serialId);
     }

--- a/src/backend/app/Services/DeviceService.php
+++ b/src/backend/app/Services/DeviceService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\Enums\DeviceType;
+use App\Enums\ManufacturerMappingStatus;
 use App\Lib\DeviceMappingResult;
 use App\Lib\IManufacturerDeviceControl;
 use App\Models\Device;
@@ -51,7 +53,7 @@ class DeviceService implements IBaseService, IAssociative {
     }
 
     /**
-     * @param array<string, mixed> $filters
+     * @param array{device_type?: DeviceType|null, appliance_id?: int, unassigned?: bool, serial?: string, manufacturer_mapping_status?: ManufacturerMappingStatus|null} $filters
      *
      * @return Collection<int, Device>|LengthAwarePaginator<int, Device>
      */
@@ -214,13 +216,13 @@ class DeviceService implements IBaseService, IAssociative {
         return $result;
     }
 
-    private function mappingStatus(DeviceMappingResult $result): string {
+    private function mappingStatus(DeviceMappingResult $result): ManufacturerMappingStatus {
         if (!$result->supported) {
-            return Device::MAPPING_STATUS_UNSUPPORTED;
+            return ManufacturerMappingStatus::Unsupported;
         }
 
         return $result->mapped
-            ? Device::MAPPING_STATUS_MAPPED
-            : Device::MAPPING_STATUS_NOT_MAPPED;
+            ? ManufacturerMappingStatus::Mapped
+            : ManufacturerMappingStatus::NotMapped;
     }
 }

--- a/src/backend/app/Services/ExportServices/DeviceExportService.php
+++ b/src/backend/app/Services/ExportServices/DeviceExportService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\ExportServices;
 
+use App\Enums\DeviceType;
 use App\Models\Device;
 use App\Models\Meter\Meter;
 use Illuminate\Support\Collection;
@@ -86,7 +87,7 @@ class DeviceExportService extends AbstractExportService {
             ];
 
             // Include meter-specific details
-            if ($device->device_type === 'meter' && $device->device instanceof Meter) {
+            if ($device->device_type === DeviceType::Meter->value && $device->device instanceof Meter) {
                 $meter = $device->device;
                 $meterType = $meter->meterType;
                 if ($meterType !== null) {
@@ -102,7 +103,7 @@ class DeviceExportService extends AbstractExportService {
             }
 
             // Include appliance name for SHS and e-bikes
-            if (in_array($device->device_type, ['solar_home_system', 'e_bike'])) {
+            if (in_array($device->device_type, [DeviceType::SolarHomeSystem->value, DeviceType::EBike->value], true)) {
                 $deviceDetails['appliance'] = $device->device->appliance->name ?? '';
             }
 

--- a/src/backend/app/Services/GeographicalInformationService.php
+++ b/src/backend/app/Services/GeographicalInformationService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\GeographicalInformation;
+use App\Models\Meter\Meter;
 use App\Services\Interfaces\IAssociative;
 use App\Services\Interfaces\IBaseService;
 use App\Traits\HasCrudOperations;
@@ -26,7 +27,7 @@ class GeographicalInformationService implements IBaseService, IAssociative {
     // This function will be removed until devices feature migration is done
     public function changeOwnerWithAddress(object $meter, int $addressId): void {
         $geoInfo = $this->geographicalInformation->newQuery()
-            ->where('owner_type', 'meter')
+            ->where('owner_type', Meter::RELATION_NAME)
             ->where('owner_id', $meter->id)
             ->first();
 

--- a/src/backend/app/Services/ImportServices/DeviceImportService.php
+++ b/src/backend/app/Services/ImportServices/DeviceImportService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\ImportServices;
 
+use App\Enums\DeviceType;
 use App\Models\Appliance;
 use App\Models\ApplianceType;
 use App\Models\ConnectionGroup;
@@ -211,23 +212,25 @@ class DeviceImportService extends AbstractImportService {
 
     private function createSpecificDevice(string $type, string $serialNumber, ?Manufacturer $manufacturer, DeviceInfoItem $info): Meter|SolarHomeSystem|EBike {
         $manufacturerId = $manufacturer?->id;
+        // Unknown types fall back to meter, matching the pre-enum import behavior.
+        $deviceType = DeviceType::tryFrom($type) ?? DeviceType::Meter;
 
-        $applianceId = in_array($type, ['solar_home_system', 'e_bike'])
+        $applianceId = in_array($deviceType, [DeviceType::SolarHomeSystem, DeviceType::EBike], true)
             ? $this->resolveApplianceId($info->appliance ?? '')
             : null;
 
-        return match ($type) {
-            'solar_home_system' => SolarHomeSystem::query()->create([
+        return match ($deviceType) {
+            DeviceType::SolarHomeSystem => SolarHomeSystem::query()->create([
                 'serial_number' => $serialNumber,
                 'manufacturer_id' => $manufacturerId,
                 'appliance_id' => $applianceId,
             ]),
-            'e_bike' => EBike::query()->create([
+            DeviceType::EBike => EBike::query()->create([
                 'serial_number' => $serialNumber,
                 'manufacturer_id' => $manufacturerId,
                 'appliance_id' => $applianceId,
             ]),
-            default => Meter::query()->create([
+            DeviceType::Meter => Meter::query()->create([
                 'serial_number' => $serialNumber,
                 'manufacturer_id' => $manufacturerId,
                 'in_use' => true,
@@ -318,9 +321,9 @@ class DeviceImportService extends AbstractImportService {
     }
 
     private function mapDeviceTypeToManufacturerType(string $deviceType): string {
-        return match ($deviceType) {
-            'solar_home_system' => 'shs',
-            'e_bike' => 'e-bike',
+        return match (DeviceType::tryFrom($deviceType)) {
+            DeviceType::SolarHomeSystem => 'shs',
+            DeviceType::EBike => 'e-bike',
             default => 'meter',
         };
     }

--- a/src/backend/app/Services/MeterRevenueService.php
+++ b/src/backend/app/Services/MeterRevenueService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\DeviceType;
 use App\Models\ConnectionGroup;
 use App\Models\Meter\Meter;
 use App\Models\Token;
@@ -49,7 +50,7 @@ class MeterRevenueService {
                     ->from('meters')
                     ->join('devices', function ($join) {
                         $join->on('devices.device_id', '=', 'meters.id')
-                            ->where('devices.device_type', '=', 'meter');
+                            ->where('devices.device_type', '=', DeviceType::Meter);
                     })
                     ->join('people', 'people.id', '=', 'devices.person_id')
                     ->join('addresses', function ($join) {
@@ -89,7 +90,7 @@ class MeterRevenueService {
                     ->from('meters')
                     ->join('devices', function ($join) {
                         $join->on('devices.device_id', '=', 'meters.id')
-                            ->where('devices.device_type', '=', 'meter');
+                            ->where('devices.device_type', '=', DeviceType::Meter);
                     })
                     ->join('people', 'people.id', '=', 'devices.person_id')
                     ->join('addresses', function ($join) {
@@ -133,7 +134,7 @@ class MeterRevenueService {
                     ->from('meters')
                     ->join('devices', function ($join) {
                         $join->on('devices.device_id', '=', 'meters.id')
-                            ->where('devices.device_type', '=', 'meter');
+                            ->where('devices.device_type', '=', DeviceType::Meter);
                     })
                     ->join('people', 'people.id', '=', 'devices.person_id')
                     ->join('addresses', function ($join) {
@@ -169,7 +170,7 @@ class MeterRevenueService {
             ->selectRaw('COUNT(meters.id) as registered_connections')
             ->join('devices', function ($join) {
                 $join->on('devices.device_id', '=', 'meters.id')
-                    ->where('devices.device_type', '=', 'meter');
+                    ->where('devices.device_type', '=', DeviceType::Meter);
             })
             ->join('people', 'people.id', '=', 'devices.person_id')
             ->join('addresses', function ($join) {
@@ -201,7 +202,7 @@ class MeterRevenueService {
             ->selectRaw('COUNT(meters.id) as registered_connections, connection_groups.name, YEARWEEK(meters.created_at, 3) as period')
             ->join('devices', function ($join) {
                 $join->on('devices.device_id', '=', 'meters.id')
-                    ->where('devices.device_type', '=', 'meter');
+                    ->where('devices.device_type', '=', DeviceType::Meter);
             })
             ->join('people', 'people.id', '=', 'devices.person_id')
             ->join('addresses', function ($join) {
@@ -235,7 +236,7 @@ class MeterRevenueService {
             ->selectRaw('COUNT(meters.serial_number) as registered_connections, connection_groups.name, YEARWEEK(meters.created_at, 3) as period')
             ->join('devices', function ($join) {
                 $join->on('devices.device_id', '=', 'meters.id')
-                    ->where('devices.device_type', '=', 'meter');
+                    ->where('devices.device_type', '=', DeviceType::Meter);
             })
             ->join('people', 'people.id', '=', 'devices.person_id')
             ->join('addresses', function ($join) {
@@ -268,7 +269,7 @@ class MeterRevenueService {
             ->selectRaw('COUNT(meters.id) as registered_connections')
             ->join('devices', function ($join) {
                 $join->on('devices.device_id', '=', 'meters.id')
-                    ->where('devices.device_type', '=', 'meter');
+                    ->where('devices.device_type', '=', DeviceType::Meter);
             })
             ->join('people', 'people.id', '=', 'devices.person_id')
             ->join('addresses', function ($join) {

--- a/src/backend/app/Services/MiniGridRevenueService.php
+++ b/src/backend/app/Services/MiniGridRevenueService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\DeviceType;
 use App\Models\Token;
 use App\Models\Transaction\Transaction;
 use Carbon\Carbon;
@@ -52,7 +53,7 @@ class MiniGridRevenueService {
         $soldEnergy = $this->token->newQuery()
             ->selectRaw('COUNT(id) as amount, SUM(token_amount) as token_amount')
             ->whereHas('device', function ($query) use ($miniGridMeters) {
-                $query->where('device_type', 'meter')
+                $query->where('device_type', DeviceType::Meter)
                     ->whereIn('device_id', $miniGridMeters->pluck('id'));
             })
             ->whereBetween('created_at', [$startDate, Carbon::parse($endDate)->endOfDay()])->get();

--- a/src/backend/app/Services/SolarHomeSystemService.php
+++ b/src/backend/app/Services/SolarHomeSystemService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\DeviceType;
 use App\Models\SolarHomeSystem;
 use App\Services\Interfaces\IBaseService;
 use App\Traits\HasCrudOperations;
@@ -89,7 +90,7 @@ class SolarHomeSystemService implements IBaseService {
                     ->selectRaw('CONCAT(p.name, " ", p.surname)')
                     ->join('people as p', 'p.id', '=', 'devices.person_id')
                     ->whereColumn('devices.device_id', 'solar_home_systems.id')
-                    ->where('devices.device_type', 'solar_home_system')
+                    ->where('devices.device_type', DeviceType::SolarHomeSystem)
                     ->limit(1);
 
                 $query->orderByRaw('('.$subquery->toSql().') '.$direction)

--- a/src/backend/app/Services/TokenService.php
+++ b/src/backend/app/Services/TokenService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\DeviceType;
 use App\Models\Token;
 use App\Services\Interfaces\IBaseService;
 use App\Traits\HasCrudOperations;
@@ -28,7 +29,7 @@ class TokenService implements IBaseService {
     public function getTokensInRange(?string $startDate, ?string $endDate): Collection {
         return $this->token->newQuery()->with(['transaction.device'])
             ->whereHas('transaction.device', function ($query) {
-                $query->where('device_type', 'meter');
+                $query->where('device_type', DeviceType::Meter);
             })
             ->whereBetween('created_at', [$startDate, $endDate])
             ->get();

--- a/src/backend/tests/Feature/DeviceManufacturerInfoTest.php
+++ b/src/backend/tests/Feature/DeviceManufacturerInfoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Enums\ManufacturerMappingStatus;
 use App\Jobs\VerifyDeviceMappingJob;
 use App\Lib\IManufacturerDeviceControl;
 use App\Models\Device;
@@ -83,14 +84,14 @@ class DeviceManufacturerInfoTest extends TestCase {
         $this->actingAs($this->user)->getJson("/api/devices/{$device->id}/device-info")->assertStatus(200);
 
         $device->refresh();
-        $this->assertSame(Device::MAPPING_STATUS_MAPPED, $device->manufacturer_mapping_status);
+        $this->assertSame(ManufacturerMappingStatus::Mapped, $device->manufacturer_mapping_status);
         $this->assertNotNull($device->manufacturer_mapping_checked_at);
     }
 
     public function testItFiltersDevicesByMappingStatus(): void {
         $this->createTestData();
-        $this->seedDevice(null, '111')->update(['manufacturer_mapping_status' => Device::MAPPING_STATUS_MAPPED]);
-        $this->seedDevice(null, '222')->update(['manufacturer_mapping_status' => Device::MAPPING_STATUS_NOT_MAPPED]);
+        $this->seedDevice(null, '111')->update(['manufacturer_mapping_status' => ManufacturerMappingStatus::Mapped]);
+        $this->seedDevice(null, '222')->update(['manufacturer_mapping_status' => ManufacturerMappingStatus::NotMapped]);
 
         $response = $this->actingAs($this->user)->getJson('/api/devices?manufacturer_mapping_status=not_mapped');
 
@@ -107,7 +108,7 @@ class DeviceManufacturerInfoTest extends TestCase {
         new VerifyDeviceMappingJob($this->companyId, $device->id)->executeJob();
 
         $device->refresh();
-        $this->assertSame(Device::MAPPING_STATUS_NOT_MAPPED, $device->manufacturer_mapping_status);
+        $this->assertSame(ManufacturerMappingStatus::NotMapped, $device->manufacturer_mapping_status);
         $this->assertNotNull($device->manufacturer_mapping_checked_at);
     }
 


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

This PR refactors the code base to consistently utilize two newly created enums `DeviceType` and `MappingStatus`.

The main motivation for this change was to improve the Device Endpoints API docs.

**Before:**

(Basically all query parameters are missing)

<img width="1491" height="806" alt="image" src="https://github.com/user-attachments/assets/37fffd3c-87d3-42ea-a162-a92d64d5e350" />


**After:**

<img width="1490" height="806" alt="image" src="https://github.com/user-attachments/assets/a7700f25-7175-4028-80f3-b48bd287a4a6" />


But using this as an opportunity to address the inconsistency issues with device types we had in the past.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
