### PR TITLE
Run GCP internal Ingress in HTTPS-only mode

### DIFF
--- a/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
@@ -41,6 +41,9 @@ patches:
   # Setting a static internal IP address and TLS for our internal loadbalancer, see
   # https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#static_ip_addressing
   # https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#https_between_client_and_load_balancer
+  # Run Internal loadbalancer "HTTPS only" mode to reduce costs (Each forwarding rule deploys
+  # a minimum of Envoy Proxy Instances).
+  # https://docs.cloud.google.com/kubernetes-engine/docs/concepts/ingress-routing-security#enforcing_https-only_traffic
   - patch: |-
       apiVersion: networking.k8s.io/v1
       kind: Ingress
@@ -48,6 +51,7 @@ patches:
         name: mpm-ingress-internal
         annotations:
           ingress.gcp.kubernetes.io/pre-shared-cert: internal-loadbalancer-cert-cloud
+          kubernetes.io/ingress.allow-http: false
           kubernetes.io/ingress.regional-static-ip-name: internal-loadbalancer-address-cloud
   - patch: |-
       apiVersion: networking.gke.io/v1

--- a/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
@@ -34,6 +34,9 @@ patches:
   # Setting a static internal IP address and TLS for our internal loadbalancer, see
   # https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#static_ip_addressing
   # https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#https_between_client_and_load_balancer
+  # Run Internal loadbalancer "HTTPS only" mode to reduce costs (Each forwarding rule deploys
+  # a minimum of Envoy Proxy Instances).
+  # https://docs.cloud.google.com/kubernetes-engine/docs/concepts/ingress-routing-security#enforcing_https-only_traffic
   - patch: |-
       apiVersion: networking.k8s.io/v1
       kind: Ingress
@@ -41,6 +44,7 @@ patches:
         name: mpm-ingress-internal
         annotations:
           ingress.gcp.kubernetes.io/pre-shared-cert: internal-loadbalancer-cert-demo
+          kubernetes.io/ingress.allow-http: false
           kubernetes.io/ingress.regional-static-ip-name: internal-loadbalancer-address-demo
   - patch: |-
       apiVersion: networking.gke.io/v1


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Implement a small cost saving measure suggested by GCP support. This will save of 6 Envoy proxy instances. Each costing ±15USD/month.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
