### PR TITLE
Run Demo on Spot Pods

### DIFF
--- a/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
@@ -26,7 +26,7 @@ patches:
   # https://docs.cloud.google.com/kubernetes-engine/docs/how-to/autopilot-spot-pods
   - target:
       kind: Deployment
-      name: "mpm-.*"
+      name: mpm-.*
     patch: |-
       - op: add
         path: /spec/template/spec/nodeSelector

--- a/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
@@ -22,6 +22,19 @@ images:
     newTag: latest
 
 patches:
+  # Run Demo on (cheaper) Spot Pods
+  # https://docs.cloud.google.com/kubernetes-engine/docs/how-to/autopilot-spot-pods
+  - target:
+      kind: Deployment
+      name: "mpm-.*"
+    patch: |-
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          cloud.google.com/gke-spot: "true"
+      - op: add
+        path: /spec/template/spec/terminationGracePeriodSeconds
+        value: 15
   # Setting a static IP external address for our external loadbalancer, see
   # https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip#use_an_ingress
   - patch: |-


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Quick change to run the MPM on Demo on evictable, but cheaper Spot pods.

This is an exploration. We need to observe how much costs this is saving and compare on how much the Demo usability suffers.

> [!NOTE]
> This PR will only get merged next week. 
> As we have recently added other cost saving measures.
> https://github.com/EnAccess/micropowermanager/pull/1566
> So, we get a better understanding about the saving quantities.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
