### PR TITLE
Add Vertifcal Pod Autoscaler

### DIFF
--- a/k8s/components/vertical_pod_autoscaler/kustomization.yaml
+++ b/k8s/components/vertical_pod_autoscaler/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - vertical_pod_autoscaler.yaml

--- a/k8s/components/vertical_pod_autoscaler/vertical_pod_autoscaler.yaml
+++ b/k8s/components/vertical_pod_autoscaler/vertical_pod_autoscaler.yaml
@@ -1,0 +1,59 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: mpm-backend
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mpm-backend
+  updatePolicy:
+    updateMode: "Off"
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: mpm-frontend
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mpm-frontend
+  updatePolicy:
+    updateMode: "Off"
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: mpm-scheduler
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mpm-scheduler
+  updatePolicy:
+    updateMode: "Off"
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: mpm-queue-worker
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mpm-queue-worker
+  updatePolicy:
+    updateMode: "Off"
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: redis-db
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: redis-db
+  updatePolicy:
+    updateMode: "Off"

--- a/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/cloud.micropowermanager.io/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
 components:
   - ../../components/internal_ingress
+  - ../../components/vertical_pod_autoscaler
 
 images:
   - name: enaccess/micropowermanager-backend:latest

--- a/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
+++ b/k8s/overlays/demo.micropowermanager.io/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
 components:
   - ../../components/internal_ingress
+  - ../../components/vertical_pod_autoscaler
 
 # customise `newTag` to deploy a specific version of MicroPowerManager
 images:


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Adding a Kubernetes Kustomize component to deploy a Vertical Pod Autoscaler (VPA) in Recommendation mode. The VPAs needs to run for a couple of days to collect data, then their recommendations are accessible via

```sh
kubectl get vpa mpm-backend -n micropowermanager-demo -o yaml
```

(adapt pod name accordingly)


### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
