### PR TITLE
fix: reclaim memory on every testcase teardown to prevent memory accumulation over the multiple test runs

### DIFF
--- a/src/backend/tests/TestCase.php
+++ b/src/backend/tests/TestCase.php
@@ -67,5 +67,13 @@ abstract class TestCase extends BaseTestCase {
     protected function tearDown(): void {
         DB::connection('tenant')->rollBack();
         parent::tearDown();
+
+        // Each test boots a fresh application whose object graph (application <->
+        // providers <-> container bindings) is a reference cycle that plain
+        // refcounting cannot reclaim. Left alone across a sequential run of the
+        // whole suite it accumulates until the process exhausts memory_limit
+        // mid-bootstrap. Forcing cycle collection after every test keeps the
+        // resident set flat.
+        gc_collect_cycles();
     }
 }


### PR DESCRIPTION

This PR fixes the recent CI test failures due to memory exceeding allowed limit.
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
