### PR TITLE
Increase test memory to match `php.ini`

### DIFF
--- a/src/backend/phpunit.xml
+++ b/src/backend/phpunit.xml
@@ -29,7 +29,7 @@
     </testsuite>
   </testsuites>
   <php>
-    <ini name="memory_limit" value="512M"/>
+    <ini name="memory_limit" value="1024M"/>
     <env name="APP_ENV" value="testing" force="true"/>
   </php>
   <source>


### PR DESCRIPTION
<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

Parity change such that the available memory for tests is the same as in Docker containers.

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [ ] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
