### PR TITLE
fix: expand `transaction_conflicts.state` to accept larger  failure message  but limit to maximum length

### DIFF
--- a/src/backend/app/Models/Transaction/TransactionConflicts.php
+++ b/src/backend/app/Models/Transaction/TransactionConflicts.php
@@ -3,9 +3,11 @@
 namespace App\Models\Transaction;
 
 use App\Models\Base\BaseModel;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 
 /**
  * Class TransactionConflicts.
@@ -19,10 +21,20 @@ use Illuminate\Support\Carbon;
  * @property-read Model       $transaction
  */
 class TransactionConflicts extends BaseModel {
+    /** Provider and manufacturer errors are stored verbatim; cap them so one runaway message cannot dominate the row. */
+    private const int STATE_MAX_LENGTH = 1000;
+
     /**
      * @return MorphTo<Model, $this>
      */
     public function transaction(): MorphTo {
         return $this->morphTo();
+    }
+
+    /**
+     * @return Attribute<never, string>
+     */
+    protected function state(): Attribute {
+        return Attribute::set(fn (?string $value): string => Str::limit($value ?? '', self::STATE_MAX_LENGTH));
     }
 }

--- a/src/backend/database/migrations/tenant/2018_06_15_082352_create_transaction_conflicts_table.php
+++ b/src/backend/database/migrations/tenant/2018_06_15_082352_create_transaction_conflicts_table.php
@@ -14,7 +14,7 @@ return new class extends Migration {
         Schema::connection('tenant')->create('transaction_conflicts', function (Blueprint $table) {
             $table->increments('id');
             $table->morphs('transaction');
-            $table->string('state'); // failed to confirm, failed to cancel
+            $table->string('state');
             $table->timestamps();
         });
     }

--- a/src/backend/database/migrations/tenant/2026_08_19_090000_use_text_datatype_for_transaction_conflicts_state.php
+++ b/src/backend/database/migrations/tenant/2026_08_19_090000_use_text_datatype_for_transaction_conflicts_state.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::connection('tenant')->table('transaction_conflicts', function (Blueprint $table) {
+            $table->text('state')->change();
+        });
+    }
+
+    public function down(): void {
+        Schema::connection('tenant')->table('transaction_conflicts', function (Blueprint $table) {
+            $table->string('state')->change();
+        });
+    }
+};

--- a/src/backend/tests/Unit/Services/TransactionFailedConflictTest.php
+++ b/src/backend/tests/Unit/Services/TransactionFailedConflictTest.php
@@ -80,6 +80,37 @@ class TransactionFailedConflictTest extends TestCase {
     }
 
     /**
+     * Manufacturer APIs fail with Guzzle messages that carry the verb, full URL, status line and a
+     * response-body excerpt, which runs well past the width `state` was originally given.
+     */
+    public function testFailedTransactionRecordsAConflictMessageLongerThanTheOldColumnWidth(): void {
+        $cashTransaction = $this->cashTransaction();
+        /** @var Transaction $transaction */
+        $transaction = $cashTransaction->transaction()->first();
+        $message = 'Manufacturer Api did not succeed after 3 times with the following error: '
+            .'Client error: `POST https://assetcontrol.central.glpapps.com/v2/token` resulted in a '
+            .'`404 Not Found` response: {"message":"Device not found","details":"'.str_repeat('x', 200).'"}';
+
+        event(new TransactionFailedEvent($transaction, $message));
+
+        $conflicts = $cashTransaction->conflicts()->get();
+        $this->assertCount(1, $conflicts);
+        $this->assertSame($message, $conflicts->first()->state);
+    }
+
+    public function testAConflictMessageIsCappedSoOneRunawayErrorCannotDominateTheRow(): void {
+        $cashTransaction = $this->cashTransaction();
+        /** @var Transaction $transaction */
+        $transaction = $cashTransaction->transaction()->first();
+
+        event(new TransactionFailedEvent($transaction, str_repeat('y', 5000)));
+
+        $state = $cashTransaction->conflicts()->first()->state;
+        $this->assertStringStartsWith(str_repeat('y', 1000), $state);
+        $this->assertLessThan(1100, strlen($state));
+    }
+
+    /**
      * A failure must not undo the settlement — PesaPal's sendResult(false) only logs.
      */
     public function testFailedPesapalTransactionKeepsItsSettledStatus(): void {


### PR DESCRIPTION
Close #1634 

<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [x] Meaningful Pull Request title and description
- [ ] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
