### PR TITLE
refactor(ui): replace city, miniGrid and village selects with autocomplete components

### DIFF
--- a/src/frontend/src/assets/sass/mpm/_misc.scss
+++ b/src/frontend/src/assets/sass/mpm/_misc.scss
@@ -179,3 +179,7 @@ input[type="file"] > input[type="button"]::-moz-focus-inner {
 .md-theme-default :not(input):not(textarea)::selection {
   background-color: #c8c8c8 !important;
 }
+
+.md-menu-content {
+  z-index: 115 !important;
+}

--- a/src/frontend/src/modules/Client/AddClientModal.vue
+++ b/src/frontend/src/modules/Client/AddClientModal.vue
@@ -207,32 +207,28 @@
                 </div>
               </div>
               <div class="md-layout-item md-size-50 md-small-size-100">
-                <md-field
+                <md-autocomplete
+                  name="city"
+                  md-input-name="city"
+                  md-input-id="city"
+                  v-model="citySearchTerm"
+                  v-validate="'required'"
                   :class="{
                     'md-invalid': errors.has('customer-add-form.city'),
                   }"
+                  :md-options="cityService.list"
+                  @md-selected="onCitySelected"
                 >
                   <label for="city">
                     {{ $tc("words.city") }}
                   </label>
-                  <md-select
-                    name="city"
-                    id="city"
-                    v-model="selectedCityId"
-                    v-validate="'required'"
-                  >
-                    <md-option
-                      v-for="city in cityService.list"
-                      :key="city.id"
-                      :value="city.id"
-                    >
-                      {{ city.name }}
-                    </md-option>
-                  </md-select>
+                  <template slot="md-autocomplete-item" slot-scope="{ item }">
+                    {{ item.name }}
+                  </template>
                   <span class="md-error">
                     {{ errors.first("customer-add-form.city") }}
                   </span>
-                </md-field>
+                </md-autocomplete>
               </div>
               <div class="md-layout-item md-size-50 md-small-size-100">
                 <md-field
@@ -301,6 +297,7 @@ export default {
       cityService: new CityService(),
       loading: false,
       selectedCityId: null,
+      citySearchTerm: "",
       phone: {
         valid: true,
       },
@@ -357,6 +354,10 @@ export default {
     },
     onPhoneInput(_, phone) {
       this.phone = phone
+    },
+    onCitySelected(city) {
+      this.selectedCityId = city.id
+      this.citySearchTerm = city.name
     },
   },
   watch: {

--- a/src/frontend/src/modules/Client/Addresses.vue
+++ b/src/frontend/src/modules/Client/Addresses.vue
@@ -66,25 +66,18 @@
       <md-dialog-content class="md-scrollbar">
         <div class="md-layout md-gutter">
           <div class="md-layout-item md-size-50 md-small-size-100">
-            <md-field name="city">
+            <md-autocomplete
+              md-input-name="city"
+              md-input-id="city"
+              v-model="citySearchTerm"
+              :md-options="cities"
+              @md-selected="onCitySelected"
+            >
               <label for="city">{{ $tc("words.city") }}</label>
-              <md-select name="city" id="city" v-model="newAddress.city_id">
-                <md-option
-                  value="0"
-                  disabled
-                  v-if="!editFlag || newAddress.city_id === null"
-                >
-                  {{ $tc("words.city") }}
-                </md-option>
-                <md-option
-                  v-for="city in cities"
-                  :key="city.id"
-                  :value="city.id"
-                >
-                  {{ city.name }}
-                </md-option>
-              </md-select>
-            </md-field>
+              <template slot="md-autocomplete-item" slot-scope="{ item }">
+                {{ item.name }}
+              </template>
+            </md-autocomplete>
           </div>
 
           <div class="md-layout-item md-size-50 md-small-size-100">
@@ -186,6 +179,7 @@ export default {
       subscriber: "personAddresses",
       modalVisibility: false,
       newAddress: {},
+      citySearchTerm: "",
       cities: [],
       editFlag: false,
       addressIndex: 0,
@@ -212,6 +206,7 @@ export default {
     },
     addNewAddress() {
       this.editFlag = false
+      this.citySearchTerm = ""
       this.showModal()
     },
     showModal() {
@@ -231,6 +226,7 @@ export default {
         city_id: address.city_id,
         primary: address.primary,
       }
+      this.citySearchTerm = address.city || ""
       this.showModal()
     },
     async getCities() {
@@ -272,7 +268,12 @@ export default {
           })
         }
         this.newAddress = {}
+        this.citySearchTerm = ""
       }
+    },
+    onCitySelected(city) {
+      this.newAddress.city_id = city.id
+      this.citySearchTerm = city.name
     },
     validatePhone(phone) {
       this.phone = phone
@@ -315,6 +316,7 @@ export default {
     closeModal() {
       this.modalVisibility = false
       this.newAddress = {}
+      this.citySearchTerm = ""
     },
     confirmDelete(address) {
       this.$swal({

--- a/src/frontend/src/modules/Client/ClientFilter.vue
+++ b/src/frontend/src/modules/Client/ClientFilter.vue
@@ -76,21 +76,16 @@
 
           <!-- Province / Village -->
           <div class="md-layout-item md-size-100">
-            <md-field>
+            <md-autocomplete
+              v-model="citySearchTerm"
+              :md-options="cities"
+              @md-selected="onCitySelected"
+            >
               <label>{{ $tc("phrases.provinceVillage") }}</label>
-              <md-select v-model="localFilters.cityId">
-                <md-option :value="null">
-                  {{ $tc("words.all") }}
-                </md-option>
-                <md-option
-                  v-for="city in cities"
-                  :key="city.id"
-                  :value="city.id"
-                >
-                  {{ city.name }}
-                </md-option>
-              </md-select>
-            </md-field>
+              <template slot="md-autocomplete-item" slot-scope="{ item }">
+                {{ item.name }}
+              </template>
+            </md-autocomplete>
           </div>
 
           <!-- Latest payment date -->
@@ -198,7 +193,11 @@ export default {
         deviceType: null,
         ...this.value,
       },
+      citySearchTerm: "",
     }
+  },
+  created() {
+    this.citySearchTerm = this.cityName(this.localFilters.cityId)
   },
   computed: {
     ...mapGetters({
@@ -225,10 +224,27 @@ export default {
             ? moment(newVal.registrationTo).toDate()
             : null,
         }
+        this.citySearchTerm = this.cityName(this.localFilters.cityId)
       },
+    },
+    citySearchTerm(newVal) {
+      // The autocomplete's built-in clear button empties this field directly,
+      // which previously mapped to the select's "All" option - mirror that by
+      // clearing the underlying filter too.
+      if (newVal === "") {
+        this.localFilters.cityId = null
+      }
     },
   },
   methods: {
+    cityName(cityId) {
+      const city = this.cities.find((city) => city.id === cityId)
+      return city ? city.name : ""
+    },
+    onCitySelected(city) {
+      this.localFilters.cityId = city.id
+      this.citySearchTerm = city.name
+    },
     normalizeDate(date, endOfDay = false) {
       if (!date) return null
       const m = moment(date)
@@ -278,6 +294,7 @@ export default {
         registrationTo: null,
         deviceType: null,
       }
+      this.citySearchTerm = ""
       const payload = this.buildPayload()
       this.$emit("input", { ...this.localFilters })
       this.$emit("clear", payload)

--- a/src/frontend/src/modules/Client/Clients.vue
+++ b/src/frontend/src/modules/Client/Clients.vue
@@ -211,19 +211,16 @@
             </md-field>
           </div>
           <div class="md-layout-item md-size-50">
-            <md-field>
+            <md-autocomplete
+              v-model="villageSearchTerm"
+              :md-options="cityService.list"
+              @md-selected="onVillageSelected"
+            >
               <label>{{ $tc("words.village") }}</label>
-              <md-select v-model="exportFilters.village">
-                <md-option value="">{{ $tc("words.all") }}</md-option>
-                <md-option
-                  v-for="city in cityService.list"
-                  :key="city.id"
-                  :value="city.name"
-                >
-                  {{ city.name }}
-                </md-option>
-              </md-select>
-            </md-field>
+              <template slot="md-autocomplete-item" slot-scope="{ item }">
+                {{ item.name }}
+              </template>
+            </md-autocomplete>
           </div>
         </div>
 
@@ -335,6 +332,7 @@ export default {
         village: "",
         deviceType: "",
       },
+      villageSearchTerm: "",
       miniGridService: new MiniGridService(),
       cityService: new CityService(),
       isSearching: false,
@@ -377,6 +375,12 @@ export default {
     searchTerm: debounce(function () {
       this.handleSearch()
     }, 300),
+    villageSearchTerm(newVal) {
+      // The autocomplete's built-in clear button empties this field directly,
+      if (newVal === "") {
+        this.exportFilters.village = ""
+      }
+    },
   },
 
   mounted() {
@@ -402,6 +406,10 @@ export default {
   },
 
   methods: {
+    onVillageSelected(city) {
+      this.exportFilters.village = city.name
+      this.villageSearchTerm = city.name
+    },
     handleSearch() {
       if (this.searchTerm.length > 2) {
         this.performSearch()

--- a/src/frontend/src/modules/Village/AddVillage.vue
+++ b/src/frontend/src/modules/Village/AddVillage.vue
@@ -25,32 +25,28 @@
               </md-field>
             </div>
             <div class="md-layout-item md-size-30 md-small-size-100">
-              <md-field
+              <md-autocomplete
+                name="miniGrid"
+                md-input-name="miniGrid"
+                md-input-id="miniGrid"
+                v-model="miniGridSearchTerm"
+                v-validate="'required'"
                 :class="{
                   'md-invalid': errors.has($tc('words.miniGrid')),
                 }"
+                :md-options="miniGridService.list"
+                @md-selected="onMiniGridSelected"
               >
                 <label for="miniGrid">
                   {{ $tc("words.miniGrid") }}
                 </label>
-                <md-select
-                  v-model="selectedMiniGridId"
-                  name="miniGrid"
-                  id="miniGrid"
-                  v-validate="'required'"
-                >
-                  <md-option
-                    v-for="mg in miniGridService.list"
-                    :value="mg.id"
-                    :key="mg.id"
-                  >
-                    {{ mg.name }}
-                  </md-option>
-                </md-select>
+                <template slot="md-autocomplete-item" slot-scope="{ item }">
+                  {{ item.name }}
+                </template>
                 <span class="md-error">
                   {{ errors.first($tc("words.miniGrid")) }}
                 </span>
-              </md-field>
+              </md-autocomplete>
             </div>
             <div class="md-layout-item md-size-30 md-small-size-100">
               <md-field
@@ -202,6 +198,7 @@ export default {
       mappingService: new MappingService(),
       redirectedMiniGridId: null,
       selectedMiniGridId: null,
+      miniGridSearchTerm: "",
       geoData: null,
       villageSaved: false,
       loading: false,
@@ -218,7 +215,7 @@ export default {
     }
   },
   created() {
-    this.redirectedMiniGridId = this.$route.params.id
+    this.redirectedMiniGridId = this.$route.query.id
     this.mappingService.setConstantMarkerUrl(ICONS.MINI_GRID)
     this.mappingService.setMarkerUrl(ICONS.VILLAGE)
     this.getCountries()
@@ -230,11 +227,12 @@ export default {
   methods: {
     async setMiniGridOfVillage() {
       try {
+        await this.getMiniGrids()
+
         if (this.redirectedMiniGridId) {
           this.selectedMiniGridId = this.redirectedMiniGridId
           return
         }
-        await this.getMiniGrids()
 
         if (this.miniGridService.list.length) {
           const selectedMiniGrid =
@@ -261,6 +259,10 @@ export default {
       } catch (e) {
         this.alertNotify("error", e.message)
       }
+    },
+    onMiniGridSelected(miniGrid) {
+      this.selectedMiniGridId = miniGrid.id
+      this.miniGridSearchTerm = miniGrid.name
     },
     async saveVillage() {
       const validator = await this.$validator.validateAll()
@@ -294,7 +296,17 @@ export default {
     },
   },
   watch: {
-    async selectedMiniGridId() {
+    async selectedMiniGridId(newVal) {
+      // Covers the two paths that set this without going through
+      // onMiniGridSelected: auto-selecting the newest mini-grid, and a
+      // redirected id arriving as a route param (always a string].
+      const selected = this.miniGridService.list.find(
+        (mg) => String(mg.id) === String(newVal),
+      )
+      if (selected) {
+        this.miniGridSearchTerm = selected.name
+      }
+
       try {
         const miniGridWithGeoData = await this.loadVillageMapContext(
           this.selectedMiniGridId,


### PR DESCRIPTION

- Replaced the `md-select` with `md-autocomplete` for city selection in AddClientModal.vue, Addresses.vue, AddVillage.vue, ClientFilter.vue, Clients.vue to use md-autocomplete for village/city selection
- Added z-index style to .md-menu-content to ensure dropdowns appear above dialogs and tooltips

<!-- First of all, thank you for your contribution to this repository! -->

<!-- Please give the Pull Request a meaningful title for the release notes -->

### Brief summary of the change made

<!-- Please include `closes: #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on: #XXXX`.-->

Closes: #1636 
### Are there any other side effects of this change that we should be aware of?

### Describe how you tested your changes?
<img width="1449" height="963" alt="Image" src="https://github.com/user-attachments/assets/18957380-782b-4820-bf33-671ef9731adf" />

For the Add Customer:
<img width="778" height="777" alt="Image" src="https://github.com/user-attachments/assets/532ee4bb-f62f-427f-b309-38fb720288a5" />

<!-- For manual testing-please provide detailed steps, screenshots, etc.. -->
<!-- If the repository provides unit tests, please add test cases covering the changes. -->

### Pull Request checklist

Please confirm you have completed any of the necessary steps below.

- [X] Meaningful Pull Request title and description
- [X] Changes tested as described above
- [ ] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
